### PR TITLE
Phase 2 statement import

### DIFF
--- a/admin/app/(dashboard)/_components/app-sidebar.tsx
+++ b/admin/app/(dashboard)/_components/app-sidebar.tsx
@@ -20,6 +20,7 @@ const navLinks = [
   { href: "/recurring-donations", label: "Recurring" },
   { href: "/transfers", label: "Transfers" },
   { href: "/organizations", label: "Organizations" },
+  { href: "/statement", label: "Statement import" },
 ];
 
 type User = {

--- a/admin/app/(dashboard)/statement/_components/statement-import.tsx
+++ b/admin/app/(dashboard)/statement/_components/statement-import.tsx
@@ -161,9 +161,9 @@ export function StatementImport() {
   const cardPayoutAssignments = useMemo(() => {
     const out: { donationId: number; archivingCode: string }[] = [];
     for (const [code, raw] of Object.entries(payoutIds)) {
-      for (const part of raw.split(/[\s,]+/).filter(Boolean)) {
+      for (const part of raw.split(/[^0-9]+/).filter(Boolean)) {
         const id = Number(part);
-        if (Number.isInteger(id))
+        if (Number.isInteger(id) && id > 0)
           out.push({ donationId: id, archivingCode: code });
       }
     }
@@ -174,7 +174,7 @@ export function StatementImport() {
     const out: { donationId: number; archivingCode: string; source: string }[] =
       [];
     for (const [code, raw] of Object.entries(manualAssign)) {
-      const id = Number(raw.trim());
+      const id = Number(raw.replace(/[^0-9]/g, ""));
       if (Number.isInteger(id) && id > 0)
         out.push({ donationId: id, archivingCode: code, source: "manual" });
     }
@@ -191,7 +191,7 @@ export function StatementImport() {
     );
     const out: { transaction: BankTxn; donorId: number }[] = [];
     for (const [code, raw] of Object.entries(manualDonor)) {
-      const donorId = Number(raw.trim());
+      const donorId = Number(raw.replace(/[^0-9]/g, ""));
       const txn = byCode.get(code);
       if (txn && Number.isInteger(donorId) && donorId > 0)
         out.push({ transaction: txn, donorId });

--- a/admin/app/(dashboard)/statement/_components/statement-import.tsx
+++ b/admin/app/(dashboard)/statement/_components/statement-import.tsx
@@ -111,8 +111,10 @@ export function StatementImport() {
   const [reconcileSel, setReconcileSel] = useState<Set<number>>(new Set());
   const [ignoreSel, setIgnoreSel] = useState<Set<string>>(new Set());
   const [payoutIds, setPayoutIds] = useState<Record<string, string>>({});
-  // needs-a-decision: archivingCode → donation id typed by the operator
+  // needs-a-decision, per archivingCode: assign to an existing donation id,
+  // or create a donation from a donor's recurring template
   const [manualAssign, setManualAssign] = useState<Record<string, string>>({});
+  const [manualDonor, setManualDonor] = useState<Record<string, string>>({});
 
   async function analyse() {
     if (!file) return;
@@ -135,6 +137,7 @@ export function StatementImport() {
       setReconcileSel(new Set(p.reconcile.map((r) => r.donationId)));
       setIgnoreSel(new Set(p.notADonation.map((t) => t.archivingCode)));
       setManualAssign({});
+      setManualDonor({});
       setPayoutIds(
         Object.fromEntries(
           p.cardPayouts
@@ -175,12 +178,31 @@ export function StatementImport() {
     return out;
   }, [manualAssign]);
 
+  const manualRecurring = useMemo(() => {
+    if (!preview) return [] as { transaction: BankTxn; donorId: number }[];
+    const byCode = new Map(
+      preview.needsDecision.map((n) => [
+        n.transaction.archivingCode,
+        n.transaction,
+      ]),
+    );
+    const out: { transaction: BankTxn; donorId: number }[] = [];
+    for (const [code, raw] of Object.entries(manualDonor)) {
+      const donorId = Number(raw.trim());
+      const txn = byCode.get(code);
+      if (txn && Number.isInteger(donorId) && donorId > 0)
+        out.push({ transaction: txn, donorId });
+    }
+    return out;
+  }, [manualDonor, preview]);
+
   const totalChanges =
     importSel.size +
     reconcileSel.size +
     ignoreSel.size +
     cardPayoutAssignments.length +
-    manualAssignments.length;
+    manualAssignments.length +
+    manualRecurring.length;
 
   async function apply() {
     if (!preview) return;
@@ -201,6 +223,7 @@ export function StatementImport() {
         recurringImports: preview.recurringImports.filter((i) =>
           importSel.has(i.archivingCode),
         ),
+        manualRecurring,
         cardPayoutAssignments,
         ignore: [
           ...preview.notADonation,
@@ -426,13 +449,18 @@ export function StatementImport() {
                   <TableHead>Sender</TableHead>
                   <TableHead>Amount</TableHead>
                   <TableHead>Why</TableHead>
-                  <TableHead className="w-40">Assign to donation #</TableHead>
+                  <TableHead className="w-32">→ donation #</TableHead>
+                  <TableHead className="w-40">→ create for donor #</TableHead>
                   <TableHead className="w-16">Ignore</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {preview.needsDecision.map((n) => {
                   const code = n.transaction.archivingCode;
+                  const resolved =
+                    ignoreSel.has(code) ||
+                    !!manualAssign[code]?.trim() ||
+                    !!manualDonor[code]?.trim();
                   return (
                     <TableRow key={code}>
                       <TableCell className="whitespace-nowrap">
@@ -452,9 +480,26 @@ export function StatementImport() {
                         <Input
                           placeholder="#"
                           value={manualAssign[code] ?? ""}
-                          disabled={ignoreSel.has(code)}
+                          disabled={
+                            ignoreSel.has(code) || !!manualDonor[code]?.trim()
+                          }
                           onChange={(e) =>
                             setManualAssign((m) => ({
+                              ...m,
+                              [code]: e.target.value,
+                            }))
+                          }
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          placeholder="donor #"
+                          value={manualDonor[code] ?? ""}
+                          disabled={
+                            ignoreSel.has(code) || !!manualAssign[code]?.trim()
+                          }
+                          onChange={(e) =>
+                            setManualDonor((m) => ({
                               ...m,
                               [code]: e.target.value,
                             }))
@@ -467,6 +512,14 @@ export function StatementImport() {
                           checked={ignoreSel.has(code)}
                           onChange={() => toggle(ignoreSel, setIgnoreSel, code)}
                         />
+                        {!resolved && (
+                          <span
+                            className="ml-1 text-xs text-amber-600"
+                            title="unresolved — will not be touched"
+                          >
+                            •
+                          </span>
+                        )}
                       </TableCell>
                     </TableRow>
                   );
@@ -522,7 +575,7 @@ export function StatementImport() {
                 : `Apply ${totalChanges} change${totalChanges === 1 ? "" : "s"}`}
             </Button>
             <span className="text-xs text-muted-foreground">
-              {importSel.size} create ·{" "}
+              {importSel.size + manualRecurring.length} create ·{" "}
               {reconcileSel.size + manualAssignments.length} reconcile ·{" "}
               {cardPayoutAssignments.length} card · {ignoreSel.size} ignore
             </span>

--- a/admin/app/(dashboard)/statement/_components/statement-import.tsx
+++ b/admin/app/(dashboard)/statement/_components/statement-import.tsx
@@ -115,6 +115,8 @@ export function StatementImport() {
   // or create a donation from a donor's recurring template
   const [manualAssign, setManualAssign] = useState<Record<string, string>>({});
   const [manualDonor, setManualDonor] = useState<Record<string, string>>({});
+  // archivingCodes whose sender→donor mapping should be persisted
+  const [rememberSel, setRememberSel] = useState<Set<string>>(new Set());
 
   async function analyse() {
     if (!file) return;
@@ -138,6 +140,7 @@ export function StatementImport() {
       setIgnoreSel(new Set(p.notADonation.map((t) => t.archivingCode)));
       setManualAssign({});
       setManualDonor({});
+      setRememberSel(new Set());
       setPayoutIds(
         Object.fromEntries(
           p.cardPayouts
@@ -196,6 +199,22 @@ export function StatementImport() {
     return out;
   }, [manualDonor, preview]);
 
+  const rememberSenders = useMemo(
+    () =>
+      manualRecurring
+        .filter(
+          (mr) =>
+            rememberSel.has(mr.transaction.archivingCode) &&
+            mr.transaction.idOrRegCode,
+        )
+        .map((mr) => ({
+          senderCode: mr.transaction.idOrRegCode,
+          donorId: mr.donorId,
+          note: mr.transaction.counterpartyName,
+        })),
+    [manualRecurring, rememberSel],
+  );
+
   const totalChanges =
     importSel.size +
     reconcileSel.size +
@@ -224,6 +243,7 @@ export function StatementImport() {
           importSel.has(i.archivingCode),
         ),
         manualRecurring,
+        rememberSenders,
         cardPayoutAssignments,
         ignore: [
           ...preview.notADonation,
@@ -505,6 +525,19 @@ export function StatementImport() {
                             }))
                           }
                         />
+                        {!!manualDonor[code]?.trim() &&
+                          !!n.transaction.idOrRegCode && (
+                            <label className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+                              <input
+                                type="checkbox"
+                                checked={rememberSel.has(code)}
+                                onChange={() =>
+                                  toggle(rememberSel, setRememberSel, code)
+                                }
+                              />
+                              remember {n.transaction.idOrRegCode}
+                            </label>
+                          )}
                       </TableCell>
                       <TableCell>
                         <input

--- a/admin/app/(dashboard)/statement/_components/statement-import.tsx
+++ b/admin/app/(dashboard)/statement/_components/statement-import.tsx
@@ -1,0 +1,466 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "../../../../components/ui/button";
+import { Badge } from "../../../../components/ui/badge";
+import { Input } from "../../../../components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../../../../components/ui/table";
+
+// ── Types (mirror backend statement service) ─────────────────────────────────
+
+type BankTxn = {
+  date: string;
+  amountCents: number;
+  archivingCode: string;
+  description: string;
+  idOrRegCode: string;
+  counterpartyName: string;
+};
+
+type RecurringImport = {
+  archivingCode: string;
+  transaction: BankTxn;
+  donorId: number;
+  templateId: number;
+  templateAmountCents: number;
+  amountCents: number;
+  datetime: string;
+  orgDonations: { organizationInternalId: string; amountCents: number }[];
+  amountDrifted: boolean;
+};
+
+type ReconcileRow = {
+  donationId: number;
+  archivingCode: string;
+  source: string;
+  amountCents: number | null;
+  datetime: string | null;
+  donorName: string | null;
+};
+
+type Preview = {
+  counts: {
+    creditTransactions: number;
+    alreadyReconciled: number;
+    ignored: number;
+  };
+  reconcile: ReconcileRow[];
+  recurringImports: RecurringImport[];
+  cardPayouts: BankTxn[];
+  needsDecision: { transaction: BankTxn; reason: string }[];
+  notADonation: BankTxn[];
+  donorNames: Record<string, string>;
+  orgNames: Record<string, string>;
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const eur = (cents: number | null) =>
+  cents == null ? "—" : `€${(cents / 100).toFixed(2)}`;
+
+function Section({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count: number;
+  children: React.ReactNode;
+}) {
+  if (count === 0) return null;
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold">
+        {title} <span className="text-muted-foreground">({count})</span>
+      </h2>
+      <div className="rounded-md border overflow-x-auto">{children}</div>
+    </section>
+  );
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export function StatementImport() {
+  const router = useRouter();
+  const [file, setFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<Preview | null>(null);
+  const [result, setResult] = useState<{
+    created: number;
+    reconciled: number;
+    ignored: number;
+  } | null>(null);
+
+  // selections
+  const [importSel, setImportSel] = useState<Set<string>>(new Set());
+  const [reconcileSel, setReconcileSel] = useState<Set<number>>(new Set());
+  const [ignoreSel, setIgnoreSel] = useState<Set<string>>(new Set());
+  const [payoutIds, setPayoutIds] = useState<Record<string, string>>({});
+
+  async function analyse() {
+    if (!file) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await fetch("/api/statement/preview", {
+        method: "POST",
+        body: form,
+      });
+      const json = await res.json();
+      if (!res.ok)
+        throw new Error(json.error?.message ?? json.error ?? "Failed");
+      const p = json as Preview;
+      setPreview(p);
+      setImportSel(new Set(p.recurringImports.map((i) => i.archivingCode)));
+      setReconcileSel(new Set(p.reconcile.map((r) => r.donationId)));
+      setIgnoreSel(new Set(p.notADonation.map((t) => t.archivingCode)));
+      setPayoutIds({});
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const cardPayoutAssignments = useMemo(() => {
+    const out: { donationId: number; archivingCode: string }[] = [];
+    for (const [code, raw] of Object.entries(payoutIds)) {
+      for (const part of raw.split(/[\s,]+/).filter(Boolean)) {
+        const id = Number(part);
+        if (Number.isInteger(id))
+          out.push({ donationId: id, archivingCode: code });
+      }
+    }
+    return out;
+  }, [payoutIds]);
+
+  const totalChanges =
+    importSel.size +
+    reconcileSel.size +
+    ignoreSel.size +
+    cardPayoutAssignments.length;
+
+  async function apply() {
+    if (!preview) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = {
+        reconcile: preview.reconcile
+          .filter((r) => reconcileSel.has(r.donationId))
+          .map((r) => ({
+            donationId: r.donationId,
+            archivingCode: r.archivingCode,
+            source: r.source,
+          })),
+        recurringImports: preview.recurringImports.filter((i) =>
+          importSel.has(i.archivingCode),
+        ),
+        cardPayoutAssignments,
+        ignore: preview.notADonation
+          .filter((t) => ignoreSel.has(t.archivingCode))
+          .map((t) => ({
+            archivingCode: t.archivingCode,
+            reason: t.description,
+          })),
+      };
+      const res = await fetch("/api/statement/apply", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (!res.ok)
+        throw new Error(json.error?.message ?? json.error ?? "Failed");
+      setResult(json);
+      setPreview(null);
+      setFile(null);
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function toggle<T>(set: Set<T>, setter: (s: Set<T>) => void, key: T) {
+    const next = new Set(set);
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    setter(next);
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Upload */}
+      <div className="flex flex-wrap items-center gap-3">
+        <Input
+          type="file"
+          accept=".csv,text/csv"
+          className="max-w-xs"
+          onChange={(e) => {
+            setFile(e.target.files?.[0] ?? null);
+            setPreview(null);
+            setResult(null);
+          }}
+        />
+        <Button onClick={analyse} disabled={!file || loading}>
+          {loading && !preview ? "Analysing…" : "Analyse"}
+        </Button>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {result && (
+        <div className="rounded-md border border-green-600/30 bg-green-600/5 p-4 text-sm">
+          Applied: <strong>{result.created}</strong> donations created,{" "}
+          <strong>{result.reconciled}</strong> reconciled,{" "}
+          <strong>{result.ignored}</strong> ignored.
+        </div>
+      )}
+
+      {preview && (
+        <>
+          <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
+            <span>{preview.counts.creditTransactions} credit lines</span>
+            <span>{preview.counts.alreadyReconciled} already done</span>
+            <span>{preview.counts.ignored} previously ignored</span>
+          </div>
+
+          <Section
+            title="Recurring payments → create donation"
+            count={preview.recurringImports.length}
+          >
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8" />
+                  <TableHead>Date</TableHead>
+                  <TableHead>Donor</TableHead>
+                  <TableHead>Paid</TableHead>
+                  <TableHead>Split</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {preview.recurringImports.map((i) => (
+                  <TableRow key={i.archivingCode}>
+                    <TableCell>
+                      <input
+                        type="checkbox"
+                        checked={importSel.has(i.archivingCode)}
+                        onChange={() =>
+                          toggle(importSel, setImportSel, i.archivingCode)
+                        }
+                      />
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      {i.transaction.date}
+                    </TableCell>
+                    <TableCell>
+                      {preview.donorNames[i.donorId] ??
+                        i.transaction.counterpartyName}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      {eur(i.amountCents)}
+                      {i.amountDrifted && (
+                        <Badge variant="secondary" className="ml-2">
+                          template {eur(i.templateAmountCents)}
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {i.orgDonations
+                        .map(
+                          (o) =>
+                            `${preview.orgNames[o.organizationInternalId] ?? o.organizationInternalId}: ${eur(o.amountCents)}`,
+                        )
+                        .join(", ")}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Section>
+
+          <Section
+            title="Bank transfers → assign transaction ID"
+            count={preview.reconcile.length}
+          >
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8" />
+                  <TableHead>Donation</TableHead>
+                  <TableHead>Donor</TableHead>
+                  <TableHead>Amount</TableHead>
+                  <TableHead>Match</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {preview.reconcile.map((r) => (
+                  <TableRow key={r.donationId}>
+                    <TableCell>
+                      <input
+                        type="checkbox"
+                        checked={reconcileSel.has(r.donationId)}
+                        onChange={() =>
+                          toggle(reconcileSel, setReconcileSel, r.donationId)
+                        }
+                      />
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      #{r.donationId}
+                    </TableCell>
+                    <TableCell>{r.donorName ?? "—"}</TableCell>
+                    <TableCell>{eur(r.amountCents)}</TableCell>
+                    <TableCell>
+                      <Badge variant="outline">{r.source}</Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Section>
+
+          <Section title="Card payouts" count={preview.cardPayouts.length}>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Net</TableHead>
+                  <TableHead>Reference</TableHead>
+                  <TableHead>Donation IDs it covers</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {preview.cardPayouts.map((t) => (
+                  <TableRow key={t.archivingCode}>
+                    <TableCell className="whitespace-nowrap">
+                      {t.date}
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      {eur(t.amountCents)}
+                    </TableCell>
+                    <TableCell className="max-w-xs truncate text-xs">
+                      {t.description}
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        placeholder="e.g. 1648, 1649"
+                        value={payoutIds[t.archivingCode] ?? ""}
+                        onChange={(e) =>
+                          setPayoutIds((m) => ({
+                            ...m,
+                            [t.archivingCode]: e.target.value,
+                          }))
+                        }
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Section>
+
+          <Section
+            title="Needs a decision — handle these outside this tool"
+            count={preview.needsDecision.length}
+          >
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date</TableHead>
+                  <TableHead>Sender</TableHead>
+                  <TableHead>Amount</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead>Why</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {preview.needsDecision.map((n) => (
+                  <TableRow key={n.transaction.archivingCode}>
+                    <TableCell className="whitespace-nowrap">
+                      {n.transaction.date}
+                    </TableCell>
+                    <TableCell>{n.transaction.counterpartyName}</TableCell>
+                    <TableCell>{eur(n.transaction.amountCents)}</TableCell>
+                    <TableCell className="max-w-xs truncate text-xs">
+                      {n.transaction.description}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {n.reason}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Section>
+
+          <Section
+            title="Not a donation → ignore"
+            count={preview.notADonation.length}
+          >
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8" />
+                  <TableHead>Date</TableHead>
+                  <TableHead>Sender</TableHead>
+                  <TableHead>Amount</TableHead>
+                  <TableHead>Description</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {preview.notADonation.map((t) => (
+                  <TableRow key={t.archivingCode}>
+                    <TableCell>
+                      <input
+                        type="checkbox"
+                        checked={ignoreSel.has(t.archivingCode)}
+                        onChange={() =>
+                          toggle(ignoreSel, setIgnoreSel, t.archivingCode)
+                        }
+                      />
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap">
+                      {t.date}
+                    </TableCell>
+                    <TableCell>{t.counterpartyName}</TableCell>
+                    <TableCell>{eur(t.amountCents)}</TableCell>
+                    <TableCell className="max-w-xs truncate text-xs">
+                      {t.description}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </Section>
+
+          <div className="sticky bottom-0 flex items-center gap-3 border-t bg-background/95 py-3">
+            <Button onClick={apply} disabled={loading || totalChanges === 0}>
+              {loading
+                ? "Applying…"
+                : `Apply ${totalChanges} change${totalChanges === 1 ? "" : "s"}`}
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {importSel.size} create · {reconcileSel.size} reconcile ·{" "}
+              {cardPayoutAssignments.length} card · {ignoreSel.size} ignore
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/admin/app/(dashboard)/statement/_components/statement-import.tsx
+++ b/admin/app/(dashboard)/statement/_components/statement-import.tsx
@@ -111,6 +111,8 @@ export function StatementImport() {
   const [reconcileSel, setReconcileSel] = useState<Set<number>>(new Set());
   const [ignoreSel, setIgnoreSel] = useState<Set<string>>(new Set());
   const [payoutIds, setPayoutIds] = useState<Record<string, string>>({});
+  // needs-a-decision: archivingCode → donation id typed by the operator
+  const [manualAssign, setManualAssign] = useState<Record<string, string>>({});
 
   async function analyse() {
     if (!file) return;
@@ -132,6 +134,7 @@ export function StatementImport() {
       setImportSel(new Set(p.recurringImports.map((i) => i.archivingCode)));
       setReconcileSel(new Set(p.reconcile.map((r) => r.donationId)));
       setIgnoreSel(new Set(p.notADonation.map((t) => t.archivingCode)));
+      setManualAssign({});
       setPayoutIds(
         Object.fromEntries(
           p.cardPayouts
@@ -161,11 +164,23 @@ export function StatementImport() {
     return out;
   }, [payoutIds]);
 
+  const manualAssignments = useMemo(() => {
+    const out: { donationId: number; archivingCode: string; source: string }[] =
+      [];
+    for (const [code, raw] of Object.entries(manualAssign)) {
+      const id = Number(raw.trim());
+      if (Number.isInteger(id) && id > 0)
+        out.push({ donationId: id, archivingCode: code, source: "manual" });
+    }
+    return out;
+  }, [manualAssign]);
+
   const totalChanges =
     importSel.size +
     reconcileSel.size +
     ignoreSel.size +
-    cardPayoutAssignments.length;
+    cardPayoutAssignments.length +
+    manualAssignments.length;
 
   async function apply() {
     if (!preview) return;
@@ -173,18 +188,24 @@ export function StatementImport() {
     setError(null);
     try {
       const payload = {
-        reconcile: preview.reconcile
-          .filter((r) => reconcileSel.has(r.donationId))
-          .map((r) => ({
-            donationId: r.donationId,
-            archivingCode: r.archivingCode,
-            source: r.source,
-          })),
+        reconcile: [
+          ...preview.reconcile
+            .filter((r) => reconcileSel.has(r.donationId))
+            .map((r) => ({
+              donationId: r.donationId,
+              archivingCode: r.archivingCode,
+              source: r.source,
+            })),
+          ...manualAssignments,
+        ],
         recurringImports: preview.recurringImports.filter((i) =>
           importSel.has(i.archivingCode),
         ),
         cardPayoutAssignments,
-        ignore: preview.notADonation
+        ignore: [
+          ...preview.notADonation,
+          ...preview.needsDecision.map((n) => n.transaction),
+        ]
           .filter((t) => ignoreSel.has(t.archivingCode))
           .map((t) => ({
             archivingCode: t.archivingCode,
@@ -395,7 +416,7 @@ export function StatementImport() {
           </Section>
 
           <Section
-            title="Needs a decision — handle these outside this tool"
+            title="Needs a decision"
             count={preview.needsDecision.length}
           >
             <Table>
@@ -404,26 +425,52 @@ export function StatementImport() {
                   <TableHead>Date</TableHead>
                   <TableHead>Sender</TableHead>
                   <TableHead>Amount</TableHead>
-                  <TableHead>Description</TableHead>
                   <TableHead>Why</TableHead>
+                  <TableHead className="w-40">Assign to donation #</TableHead>
+                  <TableHead className="w-16">Ignore</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {preview.needsDecision.map((n) => (
-                  <TableRow key={n.transaction.archivingCode}>
-                    <TableCell className="whitespace-nowrap">
-                      {n.transaction.date}
-                    </TableCell>
-                    <TableCell>{n.transaction.counterpartyName}</TableCell>
-                    <TableCell>{eur(n.transaction.amountCents)}</TableCell>
-                    <TableCell className="max-w-xs truncate text-xs">
-                      {n.transaction.description}
-                    </TableCell>
-                    <TableCell className="text-xs text-muted-foreground">
-                      {n.reason}
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {preview.needsDecision.map((n) => {
+                  const code = n.transaction.archivingCode;
+                  return (
+                    <TableRow key={code}>
+                      <TableCell className="whitespace-nowrap">
+                        {n.transaction.date}
+                      </TableCell>
+                      <TableCell>
+                        {n.transaction.counterpartyName}
+                        <span className="block max-w-xs truncate text-xs text-muted-foreground">
+                          {n.transaction.description}
+                        </span>
+                      </TableCell>
+                      <TableCell>{eur(n.transaction.amountCents)}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {n.reason}
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          placeholder="#"
+                          value={manualAssign[code] ?? ""}
+                          disabled={ignoreSel.has(code)}
+                          onChange={(e) =>
+                            setManualAssign((m) => ({
+                              ...m,
+                              [code]: e.target.value,
+                            }))
+                          }
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <input
+                          type="checkbox"
+                          checked={ignoreSel.has(code)}
+                          onChange={() => toggle(ignoreSel, setIgnoreSel, code)}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
           </Section>
@@ -475,7 +522,8 @@ export function StatementImport() {
                 : `Apply ${totalChanges} change${totalChanges === 1 ? "" : "s"}`}
             </Button>
             <span className="text-xs text-muted-foreground">
-              {importSel.size} create · {reconcileSel.size} reconcile ·{" "}
+              {importSel.size} create ·{" "}
+              {reconcileSel.size + manualAssignments.length} reconcile ·{" "}
               {cardPayoutAssignments.length} card · {ignoreSel.size} ignore
             </span>
           </div>

--- a/admin/app/(dashboard)/statement/_components/statement-import.tsx
+++ b/admin/app/(dashboard)/statement/_components/statement-import.tsx
@@ -46,6 +46,12 @@ type ReconcileRow = {
   donorName: string | null;
 };
 
+type CardPayout = {
+  transaction: BankTxn;
+  resolvedDonationIds: number[];
+  resolved: boolean;
+};
+
 type Preview = {
   counts: {
     creditTransactions: number;
@@ -54,7 +60,7 @@ type Preview = {
   };
   reconcile: ReconcileRow[];
   recurringImports: RecurringImport[];
-  cardPayouts: BankTxn[];
+  cardPayouts: CardPayout[];
   needsDecision: { transaction: BankTxn; reason: string }[];
   notADonation: BankTxn[];
   donorNames: Record<string, string>;
@@ -126,7 +132,16 @@ export function StatementImport() {
       setImportSel(new Set(p.recurringImports.map((i) => i.archivingCode)));
       setReconcileSel(new Set(p.reconcile.map((r) => r.donationId)));
       setIgnoreSel(new Set(p.notADonation.map((t) => t.archivingCode)));
-      setPayoutIds({});
+      setPayoutIds(
+        Object.fromEntries(
+          p.cardPayouts
+            .filter((c) => c.resolvedDonationIds.length > 0)
+            .map((c) => [
+              c.transaction.archivingCode,
+              c.resolvedDonationIds.join(", "),
+            ]),
+        ),
+      );
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -345,25 +360,30 @@ export function StatementImport() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {preview.cardPayouts.map((t) => (
-                  <TableRow key={t.archivingCode}>
+                {preview.cardPayouts.map((c) => (
+                  <TableRow key={c.transaction.archivingCode}>
                     <TableCell className="whitespace-nowrap">
-                      {t.date}
+                      {c.transaction.date}
                     </TableCell>
                     <TableCell className="whitespace-nowrap">
-                      {eur(t.amountCents)}
+                      {eur(c.transaction.amountCents)}
                     </TableCell>
                     <TableCell className="max-w-xs truncate text-xs">
-                      {t.description}
+                      {c.resolved && (
+                        <Badge variant="secondary" className="mr-1">
+                          Montonio
+                        </Badge>
+                      )}
+                      {c.transaction.description}
                     </TableCell>
                     <TableCell>
                       <Input
                         placeholder="e.g. 1648, 1649"
-                        value={payoutIds[t.archivingCode] ?? ""}
+                        value={payoutIds[c.transaction.archivingCode] ?? ""}
                         onChange={(e) =>
                           setPayoutIds((m) => ({
                             ...m,
-                            [t.archivingCode]: e.target.value,
+                            [c.transaction.archivingCode]: e.target.value,
                           }))
                         }
                       />

--- a/admin/app/(dashboard)/statement/page.tsx
+++ b/admin/app/(dashboard)/statement/page.tsx
@@ -1,0 +1,17 @@
+import { StatementImport } from "./_components/statement-import";
+
+export default function StatementPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Statement import</h1>
+        <p className="text-sm text-muted-foreground">
+          Upload an LHV account-statement CSV. Recurring payments become
+          donation records, bank transfers get their transaction ID, and
+          everything else is triaged.
+        </p>
+      </div>
+      <StatementImport />
+    </div>
+  );
+}

--- a/admin/app/api/statement/apply/route.ts
+++ b/admin/app/api/statement/apply/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { cookies } from "next/headers";
+import { COOKIE_NAME } from "../../../../lib/auth";
+
+const STRAPI_URL = process.env.STRAPI_URL ?? "http://localhost:1337";
+
+export async function POST(request: NextRequest) {
+  const token = (await cookies()).get(COOKIE_NAME)?.value;
+  if (!token) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const body = await request.text();
+
+  const res = await fetch(`${STRAPI_URL}/api/admin-panel/statement/apply`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body,
+  });
+
+  const text = await res.text();
+  return new NextResponse(text, {
+    status: res.status,
+    headers: {
+      "Content-Type": res.headers.get("Content-Type") ?? "application/json",
+    },
+  });
+}

--- a/admin/app/api/statement/preview/route.ts
+++ b/admin/app/api/statement/preview/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { cookies } from "next/headers";
+import { COOKIE_NAME } from "../../../../lib/auth";
+
+const STRAPI_URL = process.env.STRAPI_URL ?? "http://localhost:1337";
+
+export async function POST(request: NextRequest) {
+  const token = (await cookies()).get(COOKIE_NAME)?.value;
+  if (!token) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const form = await request.formData();
+
+  const res = await fetch(`${STRAPI_URL}/api/admin-panel/statement/preview`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: form,
+  });
+
+  const text = await res.text();
+  return new NextResponse(text, {
+    status: res.status,
+    headers: {
+      "Content-Type": res.headers.get("Content-Type") ?? "application/json",
+    },
+  });
+}

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -1,4 +1,4 @@
-import { drizzle } from "drizzle-orm/node-postgres";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Pool, PoolConfig } from "pg";
 import * as schema from "./schema";
 
@@ -33,8 +33,11 @@ export const pool = connectionString
 // Create Drizzle instance with schema for relational queries
 export const db = drizzle(pool, { schema });
 
-// Type exports for dependency injection
-export type Database = typeof db;
+// Type exports for dependency injection. `Database` covers both the pooled
+// client and a transaction handle, so repositories can be constructed with
+// either (e.g. `new DonationsRepository(tx)` inside `db.transaction(...)`).
+export type Database = NodePgDatabase<typeof schema>;
+export type Transaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 // Graceful shutdown handler
 export const closeDatabase = async (): Promise<void> => {

--- a/backend/src/db/migrations/0004_ignored_bank_transactions.sql
+++ b/backend/src/db/migrations/0004_ignored_bank_transactions.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS "ignored_bank_transactions" (
+	"archiving_code" varchar(20) PRIMARY KEY NOT NULL,
+	"reason" varchar(256),
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"created_by" varchar(256)
+);

--- a/backend/src/db/migrations/0005_sender_donor_aliases.sql
+++ b/backend/src/db/migrations/0005_sender_donor_aliases.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "sender_donor_aliases" (
+	"sender_code" varchar(64) PRIMARY KEY NOT NULL,
+	"donor_id" integer NOT NULL,
+	"note" varchar(256),
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"created_by" varchar(256)
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "sender_donor_aliases" ADD CONSTRAINT "sender_donor_aliases_donor_id_donors_id_fk" FOREIGN KEY ("donor_id") REFERENCES "public"."donors"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/backend/src/db/migrations/meta/0004_snapshot.json
+++ b/backend/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,654 @@
+{
+  "id": "bca8d1cf-7372-4043-a0a4-a71f8e7f2210",
+  "prevId": "24f11f03-4020-4083-ba01-1cc32124b825",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donation_transfers": {
+      "name": "donation_transfers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donations": {
+      "name": "donations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "donor_id": {
+          "name": "donor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_donation_id": {
+          "name": "recurring_donation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "donation_transfer_id": {
+          "name": "donation_transfer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalized": {
+          "name": "finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iban": {
+          "name": "iban",
+          "type": "varchar(34)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_code": {
+          "name": "company_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_to_organization": {
+          "name": "sent_to_organization",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_match_source": {
+          "name": "transaction_match_source",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedication_name": {
+          "name": "dedication_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedication_email": {
+          "name": "dedication_email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedication_message": {
+          "name": "dedication_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_donation": {
+          "name": "external_donation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "donations_transaction_id_idx": {
+          "name": "donations_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "donations_donor_id_donors_id_fk": {
+          "name": "donations_donor_id_donors_id_fk",
+          "tableFrom": "donations",
+          "tableTo": "donors",
+          "columnsFrom": [
+            "donor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "donations_recurring_donation_id_recurring_donations_id_fk": {
+          "name": "donations_recurring_donation_id_recurring_donations_id_fk",
+          "tableFrom": "donations",
+          "tableTo": "recurring_donations",
+          "columnsFrom": [
+            "recurring_donation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "donations_donation_transfer_id_donation_transfers_id_fk": {
+          "name": "donations_donation_transfer_id_donation_transfers_id_fk",
+          "tableFrom": "donations",
+          "tableTo": "donation_transfers",
+          "columnsFrom": [
+            "donation_transfer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donors": {
+      "name": "donors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id_code": {
+          "name": "id_code",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_donor": {
+          "name": "recurring_donor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ignored_bank_transactions": {
+      "name": "ignored_bank_transactions",
+      "schema": "",
+      "columns": {
+        "archiving_code": {
+          "name": "archiving_code",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_donations": {
+      "name": "organization_donations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "donation_id": {
+          "name": "donation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_internal_id": {
+          "name": "organization_internal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_donations_donation_id_donations_id_fk": {
+          "name": "organization_donations_donation_id_donations_id_fk",
+          "tableFrom": "organization_donations",
+          "tableTo": "donations",
+          "columnsFrom": [
+            "donation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_recurring_donations": {
+      "name": "organization_recurring_donations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recurring_donation_id": {
+          "name": "recurring_donation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_internal_id": {
+          "name": "organization_internal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_recurring_donations_recurring_donation_id_recurring_donations_id_fk": {
+          "name": "organization_recurring_donations_recurring_donation_id_recurring_donations_id_fk",
+          "tableFrom": "organization_recurring_donations",
+          "tableTo": "recurring_donations",
+          "columnsFrom": [
+            "recurring_donation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_donations": {
+      "name": "recurring_donations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "donor_id": {
+          "name": "donor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_code": {
+          "name": "company_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank": {
+          "name": "bank",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_donations_donor_id_donors_id_fk": {
+          "name": "recurring_donations_donor_id_donors_id_fk",
+          "tableFrom": "recurring_donations",
+          "tableTo": "donors",
+          "columnsFrom": [
+            "donor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/0005_snapshot.json
+++ b/backend/src/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,712 @@
+{
+  "id": "ff9eda76-2236-47e8-acc7-691867c72337",
+  "prevId": "bca8d1cf-7372-4043-a0a4-a71f8e7f2210",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_audit_log": {
+      "name": "admin_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donation_transfers": {
+      "name": "donation_transfers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donations": {
+      "name": "donations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "donor_id": {
+          "name": "donor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_donation_id": {
+          "name": "recurring_donation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "donation_transfer_id": {
+          "name": "donation_transfer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalized": {
+          "name": "finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iban": {
+          "name": "iban",
+          "type": "varchar(34)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_code": {
+          "name": "company_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_to_organization": {
+          "name": "sent_to_organization",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_match_source": {
+          "name": "transaction_match_source",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedication_name": {
+          "name": "dedication_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedication_email": {
+          "name": "dedication_email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedication_message": {
+          "name": "dedication_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_donation": {
+          "name": "external_donation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "donations_transaction_id_idx": {
+          "name": "donations_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "donations_donor_id_donors_id_fk": {
+          "name": "donations_donor_id_donors_id_fk",
+          "tableFrom": "donations",
+          "tableTo": "donors",
+          "columnsFrom": [
+            "donor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "donations_recurring_donation_id_recurring_donations_id_fk": {
+          "name": "donations_recurring_donation_id_recurring_donations_id_fk",
+          "tableFrom": "donations",
+          "tableTo": "recurring_donations",
+          "columnsFrom": [
+            "recurring_donation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "donations_donation_transfer_id_donation_transfers_id_fk": {
+          "name": "donations_donation_transfer_id_donation_transfers_id_fk",
+          "tableFrom": "donations",
+          "tableTo": "donation_transfers",
+          "columnsFrom": [
+            "donation_transfer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donors": {
+      "name": "donors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id_code": {
+          "name": "id_code",
+          "type": "varchar(11)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_donor": {
+          "name": "recurring_donor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ignored_bank_transactions": {
+      "name": "ignored_bank_transactions",
+      "schema": "",
+      "columns": {
+        "archiving_code": {
+          "name": "archiving_code",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_donations": {
+      "name": "organization_donations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "donation_id": {
+          "name": "donation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_internal_id": {
+          "name": "organization_internal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_donations_donation_id_donations_id_fk": {
+          "name": "organization_donations_donation_id_donations_id_fk",
+          "tableFrom": "organization_donations",
+          "tableTo": "donations",
+          "columnsFrom": [
+            "donation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_recurring_donations": {
+      "name": "organization_recurring_donations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recurring_donation_id": {
+          "name": "recurring_donation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_internal_id": {
+          "name": "organization_internal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_recurring_donations_recurring_donation_id_recurring_donations_id_fk": {
+          "name": "organization_recurring_donations_recurring_donation_id_recurring_donations_id_fk",
+          "tableFrom": "organization_recurring_donations",
+          "tableTo": "recurring_donations",
+          "columnsFrom": [
+            "recurring_donation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_donations": {
+      "name": "recurring_donations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "donor_id": {
+          "name": "donor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_code": {
+          "name": "company_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank": {
+          "name": "bank",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_donations_donor_id_donors_id_fk": {
+          "name": "recurring_donations_donor_id_donors_id_fk",
+          "tableFrom": "recurring_donations",
+          "tableTo": "donors",
+          "columnsFrom": [
+            "donor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sender_donor_aliases": {
+      "name": "sender_donor_aliases",
+      "schema": "",
+      "columns": {
+        "sender_code": {
+          "name": "sender_code",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "donor_id": {
+          "name": "donor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sender_donor_aliases_donor_id_donors_id_fk": {
+          "name": "sender_donor_aliases_donor_id_donors_id_fk",
+          "tableFrom": "sender_donor_aliases",
+          "tableTo": "donors",
+          "columnsFrom": [
+            "donor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1788292590316,
       "tag": "0003_donation_transaction_id",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1788299201679,
+      "tag": "0004_ignored_bank_transactions",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1788299201679,
       "tag": "0004_ignored_bank_transactions",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1788377829277,
+      "tag": "0005_sender_donor_aliases",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/repositories/donations.repository.ts
+++ b/backend/src/db/repositories/donations.repository.ts
@@ -325,7 +325,9 @@ export class DonationsRepository {
     const rows = await this.database.query.donations.findMany({
       where,
       orderBy: [asc(donations.id)],
-      with: { donor: { columns: { idCode: true } } },
+      with: {
+        donor: { columns: { idCode: true, firstName: true, lastName: true } },
+      },
     });
 
     return rows.map((d) => ({
@@ -334,6 +336,10 @@ export class DonationsRepository {
       datetime: d.datetime.toISOString(),
       companyCode: d.companyCode,
       donorIdCode: d.donor?.idCode ?? null,
+      donorName: d.donor
+        ? [d.donor.firstName, d.donor.lastName].filter(Boolean).join(" ") ||
+          null
+        : null,
     }));
   }
 

--- a/backend/src/db/repositories/donations.repository.ts
+++ b/backend/src/db/repositories/donations.repository.ts
@@ -370,15 +370,17 @@ export class DonationsRepository {
     id: number,
     transactionId: string,
     source: MatchSource,
-  ): Promise<void> {
-    await this.database
+  ): Promise<boolean> {
+    const updated = await this.database
       .update(donations)
       .set({
         transactionId,
         transactionMatchSource: source,
         updatedAt: new Date(),
       })
-      .where(eq(donations.id, id));
+      .where(eq(donations.id, id))
+      .returning({ id: donations.id });
+    return updated.length > 0;
   }
 
   /**

--- a/backend/src/db/repositories/donations.repository.ts
+++ b/backend/src/db/repositories/donations.repository.ts
@@ -278,6 +278,8 @@ export class DonationsRepository {
           data.externalDonation !== undefined ? data.externalDonation : false,
         recurringDonationId: data.recurringDonationId || null,
         donationTransferId: data.donationTransferId || null,
+        transactionId: data.transactionId || null,
+        transactionMatchSource: data.transactionMatchSource || null,
       })
       .returning();
     if (!donation) throw new Error("Failed to insert donation");
@@ -313,9 +315,15 @@ export class DonationsRepository {
    * Finalized donations in the shape the reconciliation engine expects
    * (`src/utils/reconciliation.ts`), with the donor's ID code joined in.
    */
-  async findForReconciliation(): Promise<ReconcilableDonation[]> {
+  async findForReconciliation(
+    opts: { onlyUnreconciled?: boolean } = {},
+  ): Promise<ReconcilableDonation[]> {
+    const where = opts.onlyUnreconciled
+      ? and(eq(donations.finalized, true), isNull(donations.transactionId))
+      : eq(donations.finalized, true);
+
     const rows = await this.database.query.donations.findMany({
-      where: eq(donations.finalized, true),
+      where,
       orderBy: [asc(donations.id)],
       with: { donor: { columns: { idCode: true } } },
     });
@@ -338,6 +346,20 @@ export class DonationsRepository {
       .from(donations)
       .where(isNotNull(donations.transactionId));
     return new Set(rows.map((r) => r.id));
+  }
+
+  /**
+   * The distinct set of bank transaction IDs (archiving codes) already recorded
+   * on donations — a code here means "this bank line is accounted for".
+   */
+  async reconciledTransactionIds(): Promise<Set<string>> {
+    const rows = await this.database
+      .selectDistinct({ code: donations.transactionId })
+      .from(donations)
+      .where(isNotNull(donations.transactionId));
+    return new Set(
+      rows.map((r) => r.code).filter((c): c is string => c !== null),
+    );
   }
 
   /**

--- a/backend/src/db/repositories/ignored-bank-transactions.repository.ts
+++ b/backend/src/db/repositories/ignored-bank-transactions.repository.ts
@@ -35,9 +35,9 @@ export class IgnoredBankTransactionsRepository {
       .insert(ignoredBankTransactions)
       .values(
         rows.map((r) => ({
-          archivingCode: r.archivingCode,
-          reason: r.reason ?? null,
-          createdBy: r.createdBy ?? null,
+          archivingCode: r.archivingCode.slice(0, 20),
+          reason: r.reason?.slice(0, 256) ?? null,
+          createdBy: r.createdBy?.slice(0, 256) ?? null,
         })),
       )
       .onConflictDoNothing();

--- a/backend/src/db/repositories/ignored-bank-transactions.repository.ts
+++ b/backend/src/db/repositories/ignored-bank-transactions.repository.ts
@@ -1,0 +1,55 @@
+import { inArray } from "drizzle-orm";
+import { db, type Database } from "../client";
+import {
+  ignoredBankTransactions,
+  type IgnoredBankTransaction,
+} from "../schema";
+
+export class IgnoredBankTransactionsRepository {
+  constructor(private database: Database = db) {}
+
+  async findAll(): Promise<IgnoredBankTransaction[]> {
+    return this.database.query.ignoredBankTransactions.findMany({
+      orderBy: (t, { desc }) => [desc(t.createdAt)],
+    });
+  }
+
+  /** Set of archiving codes currently marked "not a donation". */
+  async codes(): Promise<Set<string>> {
+    const rows = await this.database
+      .select({ code: ignoredBankTransactions.archivingCode })
+      .from(ignoredBankTransactions);
+    return new Set(rows.map((r) => r.code));
+  }
+
+  /** Idempotent — re-ignoring a code is a no-op. */
+  async add(
+    rows: {
+      archivingCode: string;
+      reason?: string | null;
+      createdBy?: string | null;
+    }[],
+  ): Promise<void> {
+    if (rows.length === 0) return;
+    await this.database
+      .insert(ignoredBankTransactions)
+      .values(
+        rows.map((r) => ({
+          archivingCode: r.archivingCode,
+          reason: r.reason ?? null,
+          createdBy: r.createdBy ?? null,
+        })),
+      )
+      .onConflictDoNothing();
+  }
+
+  async remove(archivingCodes: string[]): Promise<void> {
+    if (archivingCodes.length === 0) return;
+    await this.database
+      .delete(ignoredBankTransactions)
+      .where(inArray(ignoredBankTransactions.archivingCode, archivingCodes));
+  }
+}
+
+export const ignoredBankTransactionsRepository =
+  new IgnoredBankTransactionsRepository();

--- a/backend/src/db/repositories/index.ts
+++ b/backend/src/db/repositories/index.ts
@@ -23,3 +23,7 @@ export {
   ignoredBankTransactionsRepository,
   IgnoredBankTransactionsRepository,
 } from "./ignored-bank-transactions.repository";
+export {
+  senderDonorAliasesRepository,
+  SenderDonorAliasesRepository,
+} from "./sender-donor-aliases.repository";

--- a/backend/src/db/repositories/index.ts
+++ b/backend/src/db/repositories/index.ts
@@ -19,3 +19,7 @@ export {
   donationTransfersRepository,
   DonationTransfersRepository,
 } from "./donation-transfers.repository";
+export {
+  ignoredBankTransactionsRepository,
+  IgnoredBankTransactionsRepository,
+} from "./ignored-bank-transactions.repository";

--- a/backend/src/db/repositories/sender-donor-aliases.repository.ts
+++ b/backend/src/db/repositories/sender-donor-aliases.repository.ts
@@ -32,17 +32,19 @@ export class SenderDonorAliasesRepository {
   ): Promise<void> {
     if (rows.length === 0) return;
     for (const r of rows) {
+      const senderCode = r.senderCode.slice(0, 64);
+      const note = r.note?.slice(0, 256) ?? null;
       await this.database
         .insert(senderDonorAliases)
         .values({
-          senderCode: r.senderCode,
+          senderCode,
           donorId: r.donorId,
-          note: r.note ?? null,
-          createdBy: r.createdBy ?? null,
+          note,
+          createdBy: r.createdBy?.slice(0, 256) ?? null,
         })
         .onConflictDoUpdate({
           target: senderDonorAliases.senderCode,
-          set: { donorId: r.donorId, note: r.note ?? null },
+          set: { donorId: r.donorId, note },
         });
     }
   }

--- a/backend/src/db/repositories/sender-donor-aliases.repository.ts
+++ b/backend/src/db/repositories/sender-donor-aliases.repository.ts
@@ -1,0 +1,51 @@
+import { db, type Database } from "../client";
+import { senderDonorAliases, type SenderDonorAlias } from "../schema";
+
+export class SenderDonorAliasesRepository {
+  constructor(private database: Database = db) {}
+
+  async findAll(): Promise<SenderDonorAlias[]> {
+    return this.database.query.senderDonorAliases.findMany({
+      orderBy: (a, { desc }) => [desc(a.createdAt)],
+    });
+  }
+
+  /** sender code → donor id */
+  async map(): Promise<Map<string, number>> {
+    const rows = await this.database
+      .select({
+        code: senderDonorAliases.senderCode,
+        donorId: senderDonorAliases.donorId,
+      })
+      .from(senderDonorAliases);
+    return new Map(rows.map((r) => [r.code, r.donorId]));
+  }
+
+  /** Idempotent per sender code; re-adding updates the donor. */
+  async add(
+    rows: {
+      senderCode: string;
+      donorId: number;
+      note?: string | null;
+      createdBy?: string | null;
+    }[],
+  ): Promise<void> {
+    if (rows.length === 0) return;
+    for (const r of rows) {
+      await this.database
+        .insert(senderDonorAliases)
+        .values({
+          senderCode: r.senderCode,
+          donorId: r.donorId,
+          note: r.note ?? null,
+          createdBy: r.createdBy ?? null,
+        })
+        .onConflictDoUpdate({
+          target: senderDonorAliases.senderCode,
+          set: { donorId: r.donorId, note: r.note ?? null },
+        });
+    }
+  }
+}
+
+export const senderDonorAliasesRepository = new SenderDonorAliasesRepository();

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -229,3 +229,19 @@ export type IgnoredBankTransaction =
   typeof ignoredBankTransactions.$inferSelect;
 export type NewIgnoredBankTransaction =
   typeof ignoredBankTransactions.$inferInsert;
+
+// "This bank sender code belongs to this donor" — learned during a statement
+// import when the code in the bank line doesn't match any donor/template
+// (e.g. a foreign company code). Lets future imports resolve it automatically.
+export const senderDonorAliases = pgTable("sender_donor_aliases", {
+  senderCode: varchar("sender_code", { length: 64 }).primaryKey(),
+  donorId: integer("donor_id")
+    .references(() => donors.id)
+    .notNull(),
+  note: varchar("note", { length: 256 }),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  createdBy: varchar("created_by", { length: 256 }),
+});
+
+export type SenderDonorAlias = typeof senderDonorAliases.$inferSelect;
+export type NewSenderDonorAlias = typeof senderDonorAliases.$inferInsert;

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -215,3 +215,17 @@ export const adminAuditLog = pgTable("admin_audit_log", {
 
 export type AdminAuditLog = typeof adminAuditLog.$inferSelect;
 export type NewAdminAuditLog = typeof adminAuditLog.$inferInsert;
+
+// Bank-statement credit lines the operator marked "not a donation" during a
+// statement import, so they stop resurfacing on the next upload.
+export const ignoredBankTransactions = pgTable("ignored_bank_transactions", {
+  archivingCode: varchar("archiving_code", { length: 20 }).primaryKey(),
+  reason: varchar("reason", { length: 256 }),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  createdBy: varchar("created_by", { length: 256 }),
+});
+
+export type IgnoredBankTransaction =
+  typeof ignoredBankTransactions.$inferSelect;
+export type NewIgnoredBankTransaction =
+  typeof ignoredBankTransactions.$inferInsert;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -109,6 +109,8 @@ async function bootstrapDonationPermissions(
     "plugin::admin-panel.organization.stats",
     "plugin::admin-panel.dashboard.stats",
     "plugin::admin-panel.dashboard.charts",
+    "plugin::admin-panel.statement.preview",
+    "plugin::admin-panel.statement.apply", // the one write path — bank-statement import
   ];
 
   // Write actions that must be actively revoked from DonationAdmin if previously granted
@@ -134,7 +136,8 @@ async function bootstrapDonationPermissions(
       .create({
         data: {
           name: ROLE_NAME,
-          description: "Read-only access to donation admin endpoints",
+          description:
+            "Donation admin panel access (read-only, plus the bank-statement import)",
           type: "donation_admin",
         },
       })) as Role;

--- a/backend/src/plugins/admin-panel/server/controllers/index.ts
+++ b/backend/src/plugins/admin-panel/server/controllers/index.ts
@@ -4,6 +4,7 @@ import recurringDonation from "./recurringDonation";
 import transfer from "./transfer";
 import organization from "./organization";
 import dashboard from "./dashboard";
+import statement from "./statement";
 
 export default {
   donation,
@@ -12,4 +13,5 @@ export default {
   transfer,
   organization,
   dashboard,
+  statement,
 };

--- a/backend/src/plugins/admin-panel/server/controllers/statement.ts
+++ b/backend/src/plugins/admin-panel/server/controllers/statement.ts
@@ -42,6 +42,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
       const body = ctx.request.body as Partial<{
         reconcile: unknown[];
         recurringImports: unknown[];
+        manualRecurring: unknown[];
         cardPayoutAssignments: unknown[];
         ignore: unknown[];
       }>;
@@ -50,6 +51,9 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         reconcile: Array.isArray(body.reconcile) ? body.reconcile : [],
         recurringImports: Array.isArray(body.recurringImports)
           ? body.recurringImports
+          : [],
+        manualRecurring: Array.isArray(body.manualRecurring)
+          ? body.manualRecurring
           : [],
         cardPayoutAssignments: Array.isArray(body.cardPayoutAssignments)
           ? body.cardPayoutAssignments

--- a/backend/src/plugins/admin-panel/server/controllers/statement.ts
+++ b/backend/src/plugins/admin-panel/server/controllers/statement.ts
@@ -43,22 +43,19 @@ export default ({ strapi }: { strapi: Core.Strapi }) => {
         reconcile: unknown[];
         recurringImports: unknown[];
         manualRecurring: unknown[];
+        rememberSenders: unknown[];
         cardPayoutAssignments: unknown[];
         ignore: unknown[];
       }>;
 
+      const arr = (v: unknown) => (Array.isArray(v) ? v : []);
       const payload = {
-        reconcile: Array.isArray(body.reconcile) ? body.reconcile : [],
-        recurringImports: Array.isArray(body.recurringImports)
-          ? body.recurringImports
-          : [],
-        manualRecurring: Array.isArray(body.manualRecurring)
-          ? body.manualRecurring
-          : [],
-        cardPayoutAssignments: Array.isArray(body.cardPayoutAssignments)
-          ? body.cardPayoutAssignments
-          : [],
-        ignore: Array.isArray(body.ignore) ? body.ignore : [],
+        reconcile: arr(body.reconcile),
+        recurringImports: arr(body.recurringImports),
+        manualRecurring: arr(body.manualRecurring),
+        rememberSenders: arr(body.rememberSenders),
+        cardPayoutAssignments: arr(body.cardPayoutAssignments),
+        ignore: arr(body.ignore),
       };
 
       const user = ctx.state.user as { email?: string } | undefined;

--- a/backend/src/plugins/admin-panel/server/controllers/statement.ts
+++ b/backend/src/plugins/admin-panel/server/controllers/statement.ts
@@ -1,0 +1,80 @@
+import type { Core } from "@strapi/strapi";
+import type { Context } from "koa";
+import { readFileSync } from "node:fs";
+import { createStatementService } from "../services/statement";
+import { auditLog } from "../utils/audit-log";
+
+type UploadedFile = { filepath?: string; path?: string; size?: number };
+
+function firstFile(ctx: Context): UploadedFile | null {
+  const files = (
+    ctx.request as { files?: Record<string, UploadedFile | UploadedFile[]> }
+  ).files;
+  if (!files) return null;
+  const entry = Object.values(files)[0];
+  const file = Array.isArray(entry) ? entry[0] : entry;
+  return file ?? null;
+}
+
+export default ({ strapi }: { strapi: Core.Strapi }) => {
+  const service = createStatementService(strapi);
+
+  return {
+    async preview(ctx: Context) {
+      const file = firstFile(ctx);
+      const path = file?.filepath ?? file?.path;
+      if (!path) {
+        return ctx.badRequest("Upload the LHV statement CSV as a file");
+      }
+
+      let result;
+      try {
+        result = await service.preview(readFileSync(path));
+      } catch (err) {
+        return ctx.badRequest(err instanceof Error ? err.message : String(err));
+      }
+
+      await auditLog(ctx, "statement.preview");
+      return ctx.send(result);
+    },
+
+    async apply(ctx: Context) {
+      const body = ctx.request.body as Partial<{
+        reconcile: unknown[];
+        recurringImports: unknown[];
+        cardPayoutAssignments: unknown[];
+        ignore: unknown[];
+      }>;
+
+      const payload = {
+        reconcile: Array.isArray(body.reconcile) ? body.reconcile : [],
+        recurringImports: Array.isArray(body.recurringImports)
+          ? body.recurringImports
+          : [],
+        cardPayoutAssignments: Array.isArray(body.cardPayoutAssignments)
+          ? body.cardPayoutAssignments
+          : [],
+        ignore: Array.isArray(body.ignore) ? body.ignore : [],
+      };
+
+      const user = ctx.state.user as { email?: string } | undefined;
+
+      let summary;
+      try {
+        summary = await service.apply(
+          payload as never,
+          user?.email ?? "unknown",
+        );
+      } catch (err) {
+        return ctx.badRequest(err instanceof Error ? err.message : String(err));
+      }
+
+      await auditLog(
+        ctx,
+        "statement.apply",
+        `created=${summary.created} reconciled=${summary.reconciled} ignored=${summary.ignored}`,
+      );
+      return ctx.send(summary);
+    },
+  };
+};

--- a/backend/src/plugins/admin-panel/server/routes/index.ts
+++ b/backend/src/plugins/admin-panel/server/routes/index.ts
@@ -4,8 +4,13 @@ import recurringDonation from "./recurringDonation";
 import transfer from "./transfer";
 import organization from "./organization";
 import dashboard from "./dashboard";
+import statement from "./statement";
 
 export default {
+  "statement-router": {
+    type: "content-api",
+    routes: statement.routes,
+  },
   "donation-router": {
     type: "content-api",
     routes: donation.routes,

--- a/backend/src/plugins/admin-panel/server/routes/statement.ts
+++ b/backend/src/plugins/admin-panel/server/routes/statement.ts
@@ -1,0 +1,16 @@
+export default {
+  routes: [
+    {
+      method: "POST",
+      path: "/statement/preview",
+      handler: "statement.preview",
+      config: {},
+    },
+    {
+      method: "POST",
+      path: "/statement/apply",
+      handler: "statement.apply",
+      config: {},
+    },
+  ],
+};

--- a/backend/src/plugins/admin-panel/server/services/statement.ts
+++ b/backend/src/plugins/admin-panel/server/services/statement.ts
@@ -11,11 +11,13 @@ import {
   DonationsRepository,
   OrganizationDonationsRepository,
   IgnoredBankTransactionsRepository,
+  SenderDonorAliasesRepository,
   donationsRepository,
   donorsRepository,
   recurringDonationsRepository,
   organizationRecurringDonationsRepository,
   ignoredBankTransactionsRepository,
+  senderDonorAliasesRepository,
 } from "../../../../db/repositories";
 import {
   parseLhvCsv,
@@ -101,15 +103,22 @@ export interface ApplyPayload {
   recurringImports: RecurringImport[];
   /** operator pointed a "needs a decision" line at a donor → create from template */
   manualRecurring: { transaction: BankTransaction; donorId: number }[];
+  /** persist "this sender code is this donor" so future imports auto-resolve */
+  rememberSenders: {
+    senderCode: string;
+    donorId: number;
+    note?: string | null;
+  }[];
   cardPayoutAssignments: { donationId: number; archivingCode: string }[];
   ignore: { archivingCode: string; reason?: string | null }[];
 }
 
 async function loadDonorsByCode(): Promise<Map<string, DonorTemplates>> {
-  const [donors, templates, orgSplits] = await Promise.all([
+  const [donors, templates, orgSplits, aliases] = await Promise.all([
     donorsRepository.findAll(),
     recurringDonationsRepository.findAll(),
     organizationRecurringDonationsRepository.findAll(),
+    senderDonorAliasesRepository.map(),
   ]);
 
   const splitByTemplate = new Map<
@@ -153,6 +162,12 @@ async function loadDonorsByCode(): Promise<Map<string, DonorTemplates>> {
       if (t.companyCode)
         byCode.set(t.companyCode, { donorId, templates: tmpls });
     }
+  }
+  // learned aliases (foreign codes etc.) — only useful if that donor has a template
+  for (const [senderCode, donorId] of aliases) {
+    const tmpls = byDonor.get(donorId);
+    if (tmpls && tmpls.length > 0)
+      byCode.set(senderCode, { donorId, templates: tmpls });
   }
   return byCode;
 }
@@ -302,6 +317,7 @@ export function createStatementService(strapi: Core.Strapi) {
         const donationsRepo = new DonationsRepository(tx);
         const orgDonationsRepo = new OrganizationDonationsRepository(tx);
         const ignoredRepo = new IgnoredBankTransactionsRepository(tx);
+        const aliasRepo = new SenderDonorAliasesRepository(tx);
 
         for (const imp of allImports) {
           const donation = await donationsRepo.create({
@@ -354,6 +370,17 @@ export function createStatementService(strapi: Core.Strapi) {
           })),
         );
         summary.ignored = payload.ignore.length;
+
+        await aliasRepo.add(
+          (payload.rememberSenders ?? [])
+            .filter((s) => s.senderCode && Number.isInteger(s.donorId))
+            .map((s) => ({
+              senderCode: s.senderCode,
+              donorId: s.donorId,
+              note: s.note ?? null,
+              createdBy: userEmail,
+            })),
+        );
       });
 
       return summary;

--- a/backend/src/plugins/admin-panel/server/services/statement.ts
+++ b/backend/src/plugins/admin-panel/server/services/statement.ts
@@ -201,10 +201,19 @@ function planFromTemplateIndex(
   preferredTemplateId?: number,
 ): RecurringImport {
   const templates = index.byDonor.get(donorId) ?? [];
-  const template =
-    (preferredTemplateId != null &&
-      templates.find((t) => t.id === preferredTemplateId)) ||
-    selectTemplate(templates, transaction.date);
+  const dated = selectTemplate(templates, transaction.date);
+  // honour the client's template choice only if it's this donor's AND it also
+  // predates the payment; otherwise fall back to the date-selected one
+  const preferred =
+    preferredTemplateId != null
+      ? templates.find(
+          (t) =>
+            t.id === preferredTemplateId &&
+            dated != null &&
+            Date.parse(t.datetime) <= Date.parse(dated.datetime) + 1,
+        )
+      : undefined;
+  const template = preferred ?? dated;
   if (!template) {
     throw new Error(
       `Donor #${donorId} has no recurring template dated on/before ${transaction.date.slice(0, 10)}`,

--- a/backend/src/plugins/admin-panel/server/services/statement.ts
+++ b/backend/src/plugins/admin-panel/server/services/statement.ts
@@ -1,0 +1,243 @@
+/**
+ * Statement import service — turns an uploaded LHV CSV into a review plan
+ * (`preview`) and commits the operator's confirmed decisions (`apply`).
+ *
+ * Wires the pure categoriser (`utils/statement.ts`) to the DB and enriches the
+ * result with donor / organization names for the review UI.
+ */
+import type { Core } from "@strapi/strapi";
+import { db } from "../../../../db/client";
+import {
+  DonationsRepository,
+  OrganizationDonationsRepository,
+  IgnoredBankTransactionsRepository,
+  donationsRepository,
+  donorsRepository,
+  recurringDonationsRepository,
+  organizationRecurringDonationsRepository,
+  ignoredBankTransactionsRepository,
+} from "../../../../db/repositories";
+import { parseLhvCsv } from "../../../../utils/reconciliation";
+import {
+  categorizeStatement,
+  type RecurringTemplate,
+  type DonorTemplates,
+  type RecurringImport,
+  type StatementReport,
+} from "../../../../utils/statement";
+import { createOrganizationResolver } from "../../../../utils/organization-resolver";
+
+export interface ApplyPayload {
+  reconcile: { donationId: number; archivingCode: string; source: string }[];
+  recurringImports: RecurringImport[];
+  cardPayoutAssignments: { donationId: number; archivingCode: string }[];
+  ignore: { archivingCode: string; reason?: string | null }[];
+}
+
+async function loadDonorsByCode(): Promise<Map<string, DonorTemplates>> {
+  const [donors, templates, orgSplits] = await Promise.all([
+    donorsRepository.findAll(),
+    recurringDonationsRepository.findAll(),
+    organizationRecurringDonationsRepository.findAll(),
+  ]);
+
+  const splitByTemplate = new Map<
+    number,
+    { organizationInternalId: string; amount: number }[]
+  >();
+  for (const s of orgSplits) {
+    const arr = splitByTemplate.get(s.recurringDonationId) ?? [];
+    arr.push({
+      organizationInternalId: s.organizationInternalId ?? "",
+      amount: s.amount,
+    });
+    splitByTemplate.set(s.recurringDonationId, arr);
+  }
+
+  const byDonor = new Map<number, RecurringTemplate[]>();
+  for (const t of templates) {
+    const arr = byDonor.get(t.donorId) ?? [];
+    arr.push({
+      id: t.id,
+      donorId: t.donorId,
+      datetime: new Date(t.datetime).toISOString(),
+      amount: t.amount,
+      companyName: t.companyName,
+      companyCode: t.companyCode,
+      bank: t.bank,
+      orgSplit: splitByTemplate.get(t.id) ?? [],
+    });
+    byDonor.set(t.donorId, arr);
+  }
+  for (const arr of byDonor.values()) {
+    arr.sort((a, b) => Date.parse(b.datetime) - Date.parse(a.datetime));
+  }
+
+  const donorById = new Map(donors.map((d) => [d.id, d]));
+  const byCode = new Map<string, DonorTemplates>();
+  for (const [donorId, tmpls] of byDonor) {
+    const donor = donorById.get(donorId);
+    if (donor?.idCode) byCode.set(donor.idCode, { donorId, templates: tmpls });
+    for (const t of tmpls) {
+      if (t.companyCode)
+        byCode.set(t.companyCode, { donorId, templates: tmpls });
+    }
+  }
+  return byCode;
+}
+
+export function createStatementService(strapi: Core.Strapi) {
+  const orgResolver = createOrganizationResolver(strapi);
+
+  async function orgNames(ids: string[]): Promise<Record<string, string>> {
+    const unique = [...new Set(ids.filter(Boolean))];
+    const out: Record<string, string> = {};
+    await Promise.all(
+      unique.map(async (id) => {
+        const org = await orgResolver.findByInternalId(id);
+        out[id] =
+          (org as { title?: string; name?: string } | null)?.title ??
+          (org as { name?: string } | null)?.name ??
+          id;
+      }),
+    );
+    return out;
+  }
+
+  return {
+    async preview(csv: Buffer | string) {
+      const transactions = parseLhvCsv(csv);
+
+      const [
+        unreconciledDonations,
+        reconciledCodes,
+        ignoredCodes,
+        donorsByCode,
+      ] = await Promise.all([
+        donationsRepository.findForReconciliation({ onlyUnreconciled: true }),
+        donationsRepository.reconciledTransactionIds(),
+        ignoredBankTransactionsRepository.codes(),
+        loadDonorsByCode(),
+      ]);
+
+      const report: StatementReport = categorizeStatement({
+        transactions,
+        unreconciledDonations,
+        reconciledCodes,
+        ignoredCodes,
+        donorsByCode,
+      });
+
+      // ── enrichment for the review UI ──────────────────────────────────────
+      const donorIds = new Set<number>();
+      for (const i of report.recurringImports) donorIds.add(i.donorId);
+
+      const donationIds = report.reconcile.map((r) => r.donationId);
+      const [donations, donors] = await Promise.all([
+        Promise.all(
+          donationIds.map((id) =>
+            donationsRepository.findByIdWithRelations(id),
+          ),
+        ),
+        Promise.all([...donorIds].map((id) => donorsRepository.findById(id))),
+      ]);
+
+      const donorNames: Record<number, string> = {};
+      for (const d of donors) {
+        if (!d) continue;
+        donorNames[d.id] = [d.firstName, d.lastName].filter(Boolean).join(" ");
+      }
+
+      const reconcileDetail = report.reconcile.map((r, idx) => {
+        const d = donations[idx];
+        return {
+          ...r,
+          amountCents: d?.amount ?? null,
+          datetime: d?.datetime ?? null,
+          donorName: d?.donor
+            ? [d.donor.firstName, d.donor.lastName].filter(Boolean).join(" ")
+            : null,
+        };
+      });
+
+      const names = await orgNames(
+        report.recurringImports.flatMap((i) =>
+          i.orgDonations.map((o) => o.organizationInternalId),
+        ),
+      );
+
+      return {
+        counts: report.counts,
+        reconcile: reconcileDetail,
+        recurringImports: report.recurringImports,
+        cardPayouts: report.cardPayouts,
+        needsDecision: report.needsDecision,
+        notADonation: report.notADonation,
+        donorNames,
+        orgNames: names,
+      };
+    },
+
+    async apply(payload: ApplyPayload, userEmail: string) {
+      const summary = { reconciled: 0, created: 0, ignored: 0 };
+
+      await db.transaction(async (tx) => {
+        const donationsRepo = new DonationsRepository(tx);
+        const orgDonationsRepo = new OrganizationDonationsRepository(tx);
+        const ignoredRepo = new IgnoredBankTransactionsRepository(tx);
+
+        for (const imp of payload.recurringImports) {
+          const donation = await donationsRepo.create({
+            donorId: imp.donorId,
+            recurringDonationId: imp.templateId,
+            amount: imp.amountCents,
+            datetime: new Date(imp.datetime),
+            finalized: true,
+            companyName: imp.companyName,
+            companyCode: imp.companyCode,
+            iban: imp.iban,
+            paymentMethod: imp.paymentMethod,
+            transactionId: imp.archivingCode,
+            transactionMatchSource: "recurring-import",
+          });
+          await orgDonationsRepo.createMany(
+            imp.orgDonations.map((o) => ({
+              donationId: donation.id,
+              organizationInternalId: o.organizationInternalId,
+              amount: o.amountCents,
+            })),
+          );
+          summary.created++;
+        }
+
+        for (const r of payload.reconcile) {
+          await donationsRepo.setTransactionId(
+            r.donationId,
+            r.archivingCode,
+            (r.source as never) || "manual",
+          );
+          summary.reconciled++;
+        }
+        for (const a of payload.cardPayoutAssignments) {
+          await donationsRepo.setTransactionId(
+            a.donationId,
+            a.archivingCode,
+            "card-payout",
+          );
+          summary.reconciled++;
+        }
+
+        await ignoredRepo.add(
+          payload.ignore.map((i) => ({
+            archivingCode: i.archivingCode,
+            reason: i.reason ?? null,
+            createdBy: userEmail,
+          })),
+        );
+        summary.ignored = payload.ignore.length;
+      });
+
+      return summary;
+    },
+  };
+}

--- a/backend/src/plugins/admin-panel/server/services/statement.ts
+++ b/backend/src/plugins/admin-panel/server/services/statement.ts
@@ -283,19 +283,21 @@ export function createStatementService(strapi: Core.Strapi) {
         }
 
         for (const r of payload.reconcile) {
-          await donationsRepo.setTransactionId(
+          const ok = await donationsRepo.setTransactionId(
             r.donationId,
             r.archivingCode,
             (r.source as never) || "manual",
           );
+          if (!ok) throw new Error(`Donation #${r.donationId} not found`);
           summary.reconciled++;
         }
         for (const a of payload.cardPayoutAssignments) {
-          await donationsRepo.setTransactionId(
+          const ok = await donationsRepo.setTransactionId(
             a.donationId,
             a.archivingCode,
             "card-payout",
           );
+          if (!ok) throw new Error(`Donation #${a.donationId} not found`);
           summary.reconciled++;
         }
 

--- a/backend/src/plugins/admin-panel/server/services/statement.ts
+++ b/backend/src/plugins/admin-panel/server/services/statement.ts
@@ -65,14 +65,16 @@ async function resolveCardPayouts(
 
   const list = await montonio.listPayouts(100);
 
+  const toCents = (v: string | number | undefined) =>
+    v === undefined ? NaN : Math.round(Number(v) * 100);
+
   return Promise.all(
     payouts.map(async (transaction) => {
       const uuidPrefix = parsePayoutUuidPrefix(transaction.description);
-      const major = (transaction.amountCents / 100).toFixed(2);
       const payout =
         (uuidPrefix &&
           list.find((p) => p.uuid.toLowerCase().startsWith(uuidPrefix))) ||
-        list.find((p) => String(p.amount) === major);
+        list.find((p) => toCents(p.amount) === transaction.amountCents);
 
       if (!payout) {
         return { transaction, resolvedDonationIds: [], resolved: false };
@@ -113,7 +115,16 @@ export interface ApplyPayload {
   ignore: { archivingCode: string; reason?: string | null }[];
 }
 
-async function loadDonorsByCode(): Promise<Map<string, DonorTemplates>> {
+interface DonorTemplateIndex {
+  /** idCode / company code / learned alias → donor + templates */
+  byCode: Map<string, DonorTemplates>;
+  /** donor id → templates, newest first */
+  byDonor: Map<number, RecurringTemplate[]>;
+  /** donor id → display name */
+  donorName: Map<number, string>;
+}
+
+async function loadDonorTemplates(): Promise<DonorTemplateIndex> {
   const [donors, templates, orgSplits, aliases] = await Promise.all([
     donorsRepository.findAll(),
     recurringDonationsRepository.findAll(),
@@ -154,6 +165,12 @@ async function loadDonorsByCode(): Promise<Map<string, DonorTemplates>> {
   }
 
   const donorById = new Map(donors.map((d) => [d.id, d]));
+  const donorName = new Map(
+    donors.map((d) => [
+      d.id,
+      [d.firstName, d.lastName].filter(Boolean).join(" ") || `#${d.id}`,
+    ]),
+  );
   const byCode = new Map<string, DonorTemplates>();
   for (const [donorId, tmpls] of byDonor) {
     const donor = donorById.get(donorId);
@@ -169,33 +186,31 @@ async function loadDonorsByCode(): Promise<Map<string, DonorTemplates>> {
     if (tmpls && tmpls.length > 0)
       byCode.set(senderCode, { donorId, templates: tmpls });
   }
-  return byCode;
+  return { byCode, byDonor, donorName };
 }
 
-/** Templates + org splits for one donor, newest first. */
-async function loadTemplatesForDonor(
+/**
+ * Re-derive a recurring-import plan from trusted DB state — the template id the
+ * client asked for if it's still that donor's, else the one that predates the
+ * payment. Throws (aborting the apply) if there's no usable template.
+ */
+function planFromTemplateIndex(
+  index: DonorTemplateIndex,
+  transaction: BankTransaction,
   donorId: number,
-): Promise<RecurringTemplate[]> {
-  const templates = await recurringDonationsRepository.findByDonorId(donorId);
-  return Promise.all(
-    templates.map(async (t) => ({
-      id: t.id,
-      donorId: t.donorId,
-      datetime: new Date(t.datetime).toISOString(),
-      amount: t.amount,
-      companyName: t.companyName,
-      companyCode: t.companyCode,
-      bank: t.bank,
-      orgSplit: (
-        await organizationRecurringDonationsRepository.findByRecurringDonationId(
-          t.id,
-        )
-      ).map((o) => ({
-        organizationInternalId: o.organizationInternalId ?? "",
-        amount: o.amount,
-      })),
-    })),
-  );
+  preferredTemplateId?: number,
+): RecurringImport {
+  const templates = index.byDonor.get(donorId) ?? [];
+  const template =
+    (preferredTemplateId != null &&
+      templates.find((t) => t.id === preferredTemplateId)) ||
+    selectTemplate(templates, transaction.date);
+  if (!template) {
+    throw new Error(
+      `Donor #${donorId} has no recurring template dated on/before ${transaction.date.slice(0, 10)}`,
+    );
+  }
+  return planRecurringImport(transaction, template);
 }
 
 export function createStatementService(strapi: Core.Strapi) {
@@ -220,55 +235,38 @@ export function createStatementService(strapi: Core.Strapi) {
     async preview(csv: Buffer | string) {
       const transactions = parseLhvCsv(csv);
 
-      const [
-        unreconciledDonations,
-        reconciledCodes,
-        ignoredCodes,
-        donorsByCode,
-      ] = await Promise.all([
-        donationsRepository.findForReconciliation({ onlyUnreconciled: true }),
-        donationsRepository.reconciledTransactionIds(),
-        ignoredBankTransactionsRepository.codes(),
-        loadDonorsByCode(),
-      ]);
+      const [unreconciledDonations, reconciledCodes, ignoredCodes, index] =
+        await Promise.all([
+          donationsRepository.findForReconciliation({ onlyUnreconciled: true }),
+          donationsRepository.reconciledTransactionIds(),
+          ignoredBankTransactionsRepository.codes(),
+          loadDonorTemplates(),
+        ]);
 
       const report: StatementReport = categorizeStatement({
         transactions,
         unreconciledDonations,
         reconciledCodes,
         ignoredCodes,
-        donorsByCode,
+        donorsByCode: index.byCode,
       });
 
-      // ── enrichment for the review UI ──────────────────────────────────────
-      const donorIds = new Set<number>();
-      for (const i of report.recurringImports) donorIds.add(i.donorId);
-
-      const donationIds = report.reconcile.map((r) => r.donationId);
-      const [donations, donors] = await Promise.all([
-        Promise.all(
-          donationIds.map((id) =>
-            donationsRepository.findByIdWithRelations(id),
-          ),
-        ),
-        Promise.all([...donorIds].map((id) => donorsRepository.findById(id))),
-      ]);
+      // ── enrichment for the review UI (no extra queries) ───────────────────
+      const donationById = new Map(unreconciledDonations.map((d) => [d.id, d]));
 
       const donorNames: Record<number, string> = {};
-      for (const d of donors) {
-        if (!d) continue;
-        donorNames[d.id] = [d.firstName, d.lastName].filter(Boolean).join(" ");
+      for (const i of report.recurringImports) {
+        donorNames[i.donorId] =
+          index.donorName.get(i.donorId) ?? `#${i.donorId}`;
       }
 
-      const reconcileDetail = report.reconcile.map((r, idx) => {
-        const d = donations[idx];
+      const reconcileDetail = report.reconcile.map((r) => {
+        const d = donationById.get(r.donationId);
         return {
           ...r,
-          amountCents: d?.amount ?? null,
+          amountCents: d?.amountCents ?? null,
           datetime: d?.datetime ?? null,
-          donorName: d?.donor
-            ? [d.donor.firstName, d.donor.lastName].filter(Boolean).join(" ")
-            : null,
+          donorName: d?.donorName ?? null,
         };
       });
 
@@ -298,20 +296,24 @@ export function createStatementService(strapi: Core.Strapi) {
     async apply(payload: ApplyPayload, userEmail: string) {
       const summary = { reconciled: 0, created: 0, ignored: 0 };
 
-      // Resolve "needs a decision → this donor" into full plans up front
-      // (reads only), so the write transaction stays tight.
-      const manualPlans: RecurringImport[] = [];
-      for (const mr of payload.manualRecurring ?? []) {
-        const templates = await loadTemplatesForDonor(mr.donorId);
-        const template = selectTemplate(templates, mr.transaction.date);
-        if (!template) {
-          throw new Error(
-            `Donor #${mr.donorId} has no recurring template dated on/before ${mr.transaction.date}`,
-          );
-        }
-        manualPlans.push(planRecurringImport(mr.transaction, template));
-      }
-      const allImports = [...payload.recurringImports, ...manualPlans];
+      // Re-derive every recurring-import plan from current DB state — never
+      // trust the amounts / org splits the client sent back (the template or
+      // its split may have changed since preview). Done up front (reads only)
+      // so the write transaction stays tight.
+      const index = await loadDonorTemplates();
+      const allImports: RecurringImport[] = [
+        ...(payload.recurringImports ?? []).map((imp) =>
+          planFromTemplateIndex(
+            index,
+            imp.transaction,
+            imp.donorId,
+            imp.templateId,
+          ),
+        ),
+        ...(payload.manualRecurring ?? []).map((mr) =>
+          planFromTemplateIndex(index, mr.transaction, mr.donorId),
+        ),
+      ];
 
       await db.transaction(async (tx) => {
         const donationsRepo = new DonationsRepository(tx);

--- a/backend/src/plugins/admin-panel/server/services/statement.ts
+++ b/backend/src/plugins/admin-panel/server/services/statement.ts
@@ -24,6 +24,8 @@ import {
 import {
   categorizeStatement,
   parsePayoutUuidPrefix,
+  selectTemplate,
+  planRecurringImport,
   type RecurringTemplate,
   type DonorTemplates,
   type RecurringImport,
@@ -97,6 +99,8 @@ async function resolveCardPayouts(
 export interface ApplyPayload {
   reconcile: { donationId: number; archivingCode: string; source: string }[];
   recurringImports: RecurringImport[];
+  /** operator pointed a "needs a decision" line at a donor → create from template */
+  manualRecurring: { transaction: BankTransaction; donorId: number }[];
   cardPayoutAssignments: { donationId: number; archivingCode: string }[];
   ignore: { archivingCode: string; reason?: string | null }[];
 }
@@ -151,6 +155,32 @@ async function loadDonorsByCode(): Promise<Map<string, DonorTemplates>> {
     }
   }
   return byCode;
+}
+
+/** Templates + org splits for one donor, newest first. */
+async function loadTemplatesForDonor(
+  donorId: number,
+): Promise<RecurringTemplate[]> {
+  const templates = await recurringDonationsRepository.findByDonorId(donorId);
+  return Promise.all(
+    templates.map(async (t) => ({
+      id: t.id,
+      donorId: t.donorId,
+      datetime: new Date(t.datetime).toISOString(),
+      amount: t.amount,
+      companyName: t.companyName,
+      companyCode: t.companyCode,
+      bank: t.bank,
+      orgSplit: (
+        await organizationRecurringDonationsRepository.findByRecurringDonationId(
+          t.id,
+        )
+      ).map((o) => ({
+        organizationInternalId: o.organizationInternalId ?? "",
+        amount: o.amount,
+      })),
+    })),
+  );
 }
 
 export function createStatementService(strapi: Core.Strapi) {
@@ -253,12 +283,27 @@ export function createStatementService(strapi: Core.Strapi) {
     async apply(payload: ApplyPayload, userEmail: string) {
       const summary = { reconciled: 0, created: 0, ignored: 0 };
 
+      // Resolve "needs a decision → this donor" into full plans up front
+      // (reads only), so the write transaction stays tight.
+      const manualPlans: RecurringImport[] = [];
+      for (const mr of payload.manualRecurring ?? []) {
+        const templates = await loadTemplatesForDonor(mr.donorId);
+        const template = selectTemplate(templates, mr.transaction.date);
+        if (!template) {
+          throw new Error(
+            `Donor #${mr.donorId} has no recurring template dated on/before ${mr.transaction.date}`,
+          );
+        }
+        manualPlans.push(planRecurringImport(mr.transaction, template));
+      }
+      const allImports = [...payload.recurringImports, ...manualPlans];
+
       await db.transaction(async (tx) => {
         const donationsRepo = new DonationsRepository(tx);
         const orgDonationsRepo = new OrganizationDonationsRepository(tx);
         const ignoredRepo = new IgnoredBankTransactionsRepository(tx);
 
-        for (const imp of payload.recurringImports) {
+        for (const imp of allImports) {
           const donation = await donationsRepo.create({
             donorId: imp.donorId,
             recurringDonationId: imp.templateId,

--- a/backend/src/plugins/admin-panel/server/services/statement.ts
+++ b/backend/src/plugins/admin-panel/server/services/statement.ts
@@ -17,15 +17,82 @@ import {
   organizationRecurringDonationsRepository,
   ignoredBankTransactionsRepository,
 } from "../../../../db/repositories";
-import { parseLhvCsv } from "../../../../utils/reconciliation";
+import {
+  parseLhvCsv,
+  type BankTransaction,
+} from "../../../../utils/reconciliation";
 import {
   categorizeStatement,
+  parsePayoutUuidPrefix,
   type RecurringTemplate,
   type DonorTemplates,
   type RecurringImport,
   type StatementReport,
 } from "../../../../utils/statement";
 import { createOrganizationResolver } from "../../../../utils/organization-resolver";
+import montonio from "../../../../utils/montonio";
+
+/** Trailing donation id in a Montonio merchant reference (`<prefix> <id>`). */
+function refToDonationId(ref: string | undefined): number | null {
+  if (!ref) return null;
+  const m = /(\d+)\s*$/.exec(ref);
+  return m ? Number(m[1]) : null;
+}
+
+export interface ResolvedCardPayout {
+  transaction: BankTransaction;
+  /** donation ids the Montonio payout says it covers, still unreconciled */
+  resolvedDonationIds: number[];
+  /** false when the Montonio lookup failed and manual entry is needed */
+  resolved: boolean;
+}
+
+async function resolveCardPayouts(
+  payouts: BankTransaction[],
+  unreconciledIds: Set<number>,
+): Promise<ResolvedCardPayout[]> {
+  if (payouts.length === 0 || !montonio.isPayoutsConfigured()) {
+    return payouts.map((transaction) => ({
+      transaction,
+      resolvedDonationIds: [],
+      resolved: false,
+    }));
+  }
+
+  const list = await montonio.listPayouts(100);
+
+  return Promise.all(
+    payouts.map(async (transaction) => {
+      const uuidPrefix = parsePayoutUuidPrefix(transaction.description);
+      const major = (transaction.amountCents / 100).toFixed(2);
+      const payout =
+        (uuidPrefix &&
+          list.find((p) => p.uuid.toLowerCase().startsWith(uuidPrefix))) ||
+        list.find((p) => String(p.amount) === major);
+
+      if (!payout) {
+        return { transaction, resolvedDonationIds: [], resolved: false };
+      }
+
+      const orders = await montonio.getPayoutOrders(payout.uuid);
+      if (!orders) {
+        return { transaction, resolvedDonationIds: [], resolved: false };
+      }
+
+      const ids = orders
+        .map((o) =>
+          refToDonationId(o.merchantReference ?? o.merchant_reference),
+        )
+        .filter((id): id is number => id !== null && unreconciledIds.has(id));
+
+      return {
+        transaction,
+        resolvedDonationIds: [...new Set(ids)],
+        resolved: true,
+      };
+    }),
+  );
+}
 
 export interface ApplyPayload {
   reconcile: { donationId: number; archivingCode: string; source: string }[];
@@ -166,11 +233,16 @@ export function createStatementService(strapi: Core.Strapi) {
         ),
       );
 
+      const cardPayouts = await resolveCardPayouts(
+        report.cardPayouts,
+        new Set(unreconciledDonations.map((d) => d.id)),
+      );
+
       return {
         counts: report.counts,
         reconcile: reconcileDetail,
         recurringImports: report.recurringImports,
-        cardPayouts: report.cardPayouts,
+        cardPayouts,
         needsDecision: report.needsDecision,
         notADonation: report.notADonation,
         donorNames,

--- a/backend/src/utils/__tests__/statement.test.ts
+++ b/backend/src/utils/__tests__/statement.test.ts
@@ -165,6 +165,12 @@ describe("planRecurringImport", () => {
     );
     expect(plan.orgDonations.reduce((s, o) => s + o.amountCents, 0)).toBe(1000);
   });
+
+  it("throws on a template with no org split (rather than crashing on resize)", () => {
+    expect(() =>
+      planRecurringImport(txn({}), template({ orgSplit: [] })),
+    ).toThrow(/no organization split/);
+  });
 });
 
 // ─── categorizeStatement ─────────────────────────────────────────────────────
@@ -195,6 +201,63 @@ describe("categorizeStatement", () => {
     expect(report.counts).toMatchObject({ alreadyReconciled: 1, ignored: 1 });
     expect(report.recurringImports).toHaveLength(0);
     expect(report.notADonation).toHaveLength(0);
+  });
+
+  it("never re-reconciles a code that is already on a donation or ignored, even if matchDonations finds a same-amount donation in the window", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [
+          txn({ archivingCode: "DONE", amountCents: 3000, date: "2026-06-15" }),
+          txn({
+            archivingCode: "IGN",
+            amountCents: 3000,
+            date: "2026-06-15",
+            idOrRegCode: "38000000000",
+          }),
+        ],
+        unreconciledDonations: [
+          donation({ id: 7, amountCents: 3000, donorIdCode: "39001010001" }),
+          donation({ id: 8, amountCents: 3000, donorIdCode: "38000000000" }),
+        ],
+        reconciledCodes: new Set(["DONE"]),
+        ignoredCodes: new Set(["IGN"]),
+      }),
+    );
+    expect(report.reconcile).toHaveLength(0);
+    expect(report.counts).toMatchObject({ alreadyReconciled: 1, ignored: 1 });
+  });
+
+  it("a code matching >1 existing donation goes to needs-a-decision, not auto-reconcile", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [
+          txn({ archivingCode: "DUP", amountCents: 3000, date: "2026-06-15" }),
+        ],
+        unreconciledDonations: [
+          donation({ id: 7, amountCents: 3000 }),
+          donation({ id: 8, amountCents: 3000 }),
+        ],
+      }),
+    );
+    expect(report.reconcile).toHaveLength(0);
+    expect(report.needsDecision).toHaveLength(1);
+    expect(report.needsDecision[0].reason).toMatch(/matches 2 existing/);
+  });
+
+  it("recurring template with no org split → needs a decision, not a crash", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [txn({ archivingCode: "NOSPLIT", amountCents: 3000 })],
+        donorsByCode: new Map<string, DonorTemplates>([
+          [
+            "39001010001",
+            { donorId: 10, templates: [template({ orgSplit: [] })] },
+          ],
+        ]),
+      }),
+    );
+    expect(report.recurringImports).toHaveLength(0);
+    expect(report.needsDecision[0].reason).toMatch(/no organization split/);
   });
 
   it("assigns a code to an existing unreconciled donation (step 2 wins over import)", () => {

--- a/backend/src/utils/__tests__/statement.test.ts
+++ b/backend/src/utils/__tests__/statement.test.ts
@@ -280,28 +280,6 @@ describe("categorizeStatement", () => {
     expect(report.notADonation).toHaveLength(0);
   });
 
-  it("tax-board rebate → not a donation, by reg code or name", () => {
-    const report = categorizeStatement(
-      baseInput({
-        transactions: [
-          txn({
-            archivingCode: "TAX1",
-            idOrRegCode: "70000272",
-            counterpartyName: "Rahandusministeerium",
-            description:
-              "MAKSU JA TOLLIAMET tulumaks, Fidek 2024, annetus, isikukood 39001010001",
-          }),
-        ],
-        // even though this idCode maps to a donor with a template:
-        donorsByCode: new Map([
-          ["70000272", { donorId: 5, templates: [template({})] }],
-        ]),
-      }),
-    );
-    expect(report.notADonation.map((t) => t.archivingCode)).toEqual(["TAX1"]);
-    expect(report.recurringImports).toHaveLength(0);
-  });
-
   it("everything else → not a donation", () => {
     const report = categorizeStatement(
       baseInput({

--- a/backend/src/utils/__tests__/statement.test.ts
+++ b/backend/src/utils/__tests__/statement.test.ts
@@ -280,6 +280,28 @@ describe("categorizeStatement", () => {
     expect(report.notADonation).toHaveLength(0);
   });
 
+  it("tax-board rebate → not a donation, by reg code or name", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [
+          txn({
+            archivingCode: "TAX1",
+            idOrRegCode: "70000272",
+            counterpartyName: "Rahandusministeerium",
+            description:
+              "MAKSU JA TOLLIAMET tulumaks, Fidek 2024, annetus, isikukood 39001010001",
+          }),
+        ],
+        // even though this idCode maps to a donor with a template:
+        donorsByCode: new Map([
+          ["70000272", { donorId: 5, templates: [template({})] }],
+        ]),
+      }),
+    );
+    expect(report.notADonation.map((t) => t.archivingCode)).toEqual(["TAX1"]);
+    expect(report.recurringImports).toHaveLength(0);
+  });
+
   it("everything else → not a donation", () => {
     const report = categorizeStatement(
       baseInput({

--- a/backend/src/utils/__tests__/statement.test.ts
+++ b/backend/src/utils/__tests__/statement.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect } from "vitest";
+import {
+  categorizeStatement,
+  selectTemplate,
+  planRecurringImport,
+  looksLikeCardPayout,
+  parsePayoutUuidPrefix,
+  type RecurringTemplate,
+  type DonorTemplates,
+  type StatementInput,
+} from "../statement";
+import type { BankTransaction, ReconcilableDonation } from "../reconciliation";
+
+function txn(o: Partial<BankTransaction>): BankTransaction {
+  return {
+    date: "2026-06-15",
+    amountCents: 3000,
+    archivingCode: "2026061500000001",
+    description: "Anneta Targalt püsiannetus",
+    idOrRegCode: "39001010001",
+    counterpartyAccount: "EE001",
+    counterpartyName: "Test Testija",
+    direction: "C",
+    ...o,
+  };
+}
+
+function template(o: Partial<RecurringTemplate>): RecurringTemplate {
+  return {
+    id: 1,
+    donorId: 10,
+    datetime: "2026-01-01T00:00:00.000Z",
+    amount: 3000,
+    companyName: null,
+    companyCode: null,
+    bank: "swedbank",
+    orgSplit: [
+      { organizationInternalId: "ORG-A", amount: 2000 },
+      { organizationInternalId: "ORG-B", amount: 1000 },
+    ],
+    ...o,
+  };
+}
+
+function baseInput(o: Partial<StatementInput>): StatementInput {
+  return {
+    transactions: [],
+    unreconciledDonations: [],
+    reconciledCodes: new Set(),
+    ignoredCodes: new Set(),
+    donorsByCode: new Map(),
+    ...o,
+  };
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+describe("looksLikeCardPayout", () => {
+  it("recognises Montonio payouts and the STRIPE/MONTONIO label", () => {
+    expect(
+      looksLikeCardPayout(
+        txn({
+          counterpartyName: "Montonio Finance UAB",
+          description: "Card payout abc",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      looksLikeCardPayout(
+        txn({ counterpartyName: "STRIPE", description: "MONTONIO FINANCE" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("leaves a normal donor transfer alone", () => {
+    expect(
+      looksLikeCardPayout(
+        txn({
+          counterpartyName: "Jaan Tamm",
+          description: "Anneta Targalt annetus 5",
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("parsePayoutUuidPrefix", () => {
+  it("pulls the (possibly truncated) uuid out of the Selgitus", () => {
+    expect(
+      parsePayoutUuidPrefix("Card payout faab4de5-117b-493d-b4d2-63b0f38bb"),
+    ).toBe("faab4de5-117b-493d-b4d2-63b0f38bb");
+    expect(parsePayoutUuidPrefix("Anneta Targalt annetus 5")).toBeNull();
+  });
+});
+
+// ─── selectTemplate ──────────────────────────────────────────────────────────
+
+describe("selectTemplate", () => {
+  const newest = template({ id: 3, datetime: "2026-05-01T00:00:00Z" });
+  const middle = template({ id: 2, datetime: "2026-03-01T00:00:00Z" });
+  const oldest = template({ id: 1, datetime: "2026-01-01T00:00:00Z" });
+  const templates = [newest, middle, oldest]; // newest first, as the repo returns
+
+  it("picks the newest template that predates the payment", () => {
+    expect(selectTemplate(templates, "2026-04-10")?.id).toBe(2);
+    expect(selectTemplate(templates, "2026-06-10")?.id).toBe(3);
+  });
+
+  it("allows a 24h grace (template created later the same day), not well after", () => {
+    expect(
+      selectTemplate(
+        [template({ id: 9, datetime: "2026-06-10T18:00:00Z" })],
+        "2026-06-10",
+      )?.id,
+    ).toBe(9);
+    expect(
+      selectTemplate(
+        [template({ id: 9, datetime: "2026-06-11T09:00:00Z" })],
+        "2026-06-10",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when every template is newer than the payment", () => {
+    expect(selectTemplate(templates, "2025-12-01")).toBeNull();
+  });
+});
+
+// ─── planRecurringImport ─────────────────────────────────────────────────────
+
+describe("planRecurringImport", () => {
+  it("copies the template split when the amount matches", () => {
+    const plan = planRecurringImport(txn({ amountCents: 3000 }), template({}));
+    expect(plan.amountDrifted).toBe(false);
+    expect(plan.orgDonations).toEqual([
+      { organizationInternalId: "ORG-A", amountCents: 2000 },
+      { organizationInternalId: "ORG-B", amountCents: 1000 },
+    ]);
+    expect(plan.paymentMethod).toBe("swedbank");
+    expect(plan.iban).toBe("EE001");
+    expect(plan.archivingCode).toBe("2026061500000001");
+  });
+
+  it("scales the split proportionally on amount drift, and still sums exactly", () => {
+    const plan = planRecurringImport(
+      txn({ amountCents: 1000 }),
+      template({ amount: 3000 }),
+    );
+    expect(plan.amountDrifted).toBe(true);
+    const total = plan.orgDonations.reduce((s, o) => s + o.amountCents, 0);
+    expect(total).toBe(1000);
+  });
+
+  it("handles a rounding remainder without losing cents", () => {
+    const plan = planRecurringImport(
+      txn({ amountCents: 1000 }),
+      template({
+        amount: 3000,
+        orgSplit: [
+          { organizationInternalId: "A", amount: 1000 },
+          { organizationInternalId: "B", amount: 1000 },
+          { organizationInternalId: "C", amount: 1000 },
+        ],
+      }),
+    );
+    expect(plan.orgDonations.reduce((s, o) => s + o.amountCents, 0)).toBe(1000);
+  });
+});
+
+// ─── categorizeStatement ─────────────────────────────────────────────────────
+
+function donation(o: Partial<ReconcilableDonation>): ReconcilableDonation {
+  return {
+    id: 1,
+    amountCents: 3000,
+    datetime: "2026-06-14T10:00:00Z",
+    companyCode: null,
+    donorIdCode: "39001010001",
+    ...o,
+  };
+}
+
+describe("categorizeStatement", () => {
+  it("counts already-reconciled and ignored codes, acts on neither", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [
+          txn({ archivingCode: "DONE" }),
+          txn({ archivingCode: "IGNORED" }),
+        ],
+        reconciledCodes: new Set(["DONE"]),
+        ignoredCodes: new Set(["IGNORED"]),
+      }),
+    );
+    expect(report.counts).toMatchObject({ alreadyReconciled: 1, ignored: 1 });
+    expect(report.recurringImports).toHaveLength(0);
+    expect(report.notADonation).toHaveLength(0);
+  });
+
+  it("assigns a code to an existing unreconciled donation (step 2 wins over import)", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [
+          txn({ archivingCode: "X", amountCents: 3000, date: "2026-06-15" }),
+        ],
+        unreconciledDonations: [donation({ id: 7, amountCents: 3000 })],
+        donorsByCode: new Map([
+          ["39001010001", { donorId: 10, templates: [template({})] }],
+        ]),
+      }),
+    );
+    expect(report.reconcile).toEqual([
+      { donationId: 7, archivingCode: "X", source: "idcode-amount-date" },
+    ]);
+    expect(report.recurringImports).toHaveLength(0);
+  });
+
+  it("plans a recurring import when no donation exists yet", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [txn({ archivingCode: "NEW", amountCents: 3000 })],
+        donorsByCode: new Map<string, DonorTemplates>([
+          ["39001010001", { donorId: 10, templates: [template({})] }],
+        ]),
+      }),
+    );
+    expect(report.recurringImports).toHaveLength(1);
+    expect(report.recurringImports[0]).toMatchObject({
+      archivingCode: "NEW",
+      donorId: 10,
+      templateId: 1,
+      amountCents: 3000,
+    });
+  });
+
+  it("routes card payouts to their own bucket", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [
+          txn({
+            archivingCode: "P",
+            counterpartyName: "Montonio Finance UAB",
+            description: "Card payout abc123",
+            amountCents: 29263,
+          }),
+        ],
+      }),
+    );
+    expect(report.cardPayouts).toHaveLength(1);
+    expect(report.recurringImports).toHaveLength(0);
+  });
+
+  it("known donor with no template → needs a decision, not an import", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [txn({ archivingCode: "Q" })],
+        donorsByCode: new Map([
+          ["39001010001", { donorId: 10, templates: [] }],
+        ]),
+      }),
+    );
+    expect(report.recurringImports).toHaveLength(0);
+    expect(report.needsDecision).toHaveLength(1);
+    expect(report.needsDecision[0].reason).toMatch(/no recurring template/);
+  });
+
+  it("donation-like Selgitus from an unknown sender → needs a decision", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [
+          txn({
+            archivingCode: "R",
+            idOrRegCode: "99999999999",
+            description: "Anneta Targalt annetus",
+          }),
+        ],
+      }),
+    );
+    expect(report.needsDecision).toHaveLength(1);
+    expect(report.notADonation).toHaveLength(0);
+  });
+
+  it("everything else → not a donation", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [
+          txn({
+            archivingCode: "S",
+            idOrRegCode: "",
+            counterpartyName: "Some Foundation",
+            description: "Saadud intress",
+          }),
+        ],
+      }),
+    );
+    expect(report.notADonation).toHaveLength(1);
+  });
+
+  it("ignores debit rows and rows with no archiving code", () => {
+    const report = categorizeStatement(
+      baseInput({
+        transactions: [
+          txn({ direction: "D", archivingCode: "D1" }),
+          txn({ archivingCode: "" }),
+        ],
+      }),
+    );
+    expect(report.counts.creditTransactions).toBe(0);
+  });
+});

--- a/backend/src/utils/montonio.ts
+++ b/backend/src/utils/montonio.ts
@@ -69,7 +69,10 @@ const montonio = {
    * Decode and verify a Montonio order token.
    */
   decodeOrderToken: (orderToken: string): MontonioDecodedToken => {
-    const decoded = jwt.verify(orderToken, getPrivateKey()) as MontonioDecodedToken;
+    const decoded = jwt.verify(
+      orderToken,
+      getPrivateKey(),
+    ) as MontonioDecodedToken;
 
     if (decoded.accessKey === getPublicKey()) {
       return decoded;
@@ -77,6 +80,95 @@ const montonio = {
       throw new Error("Invalid public key");
     }
   },
+
+  // ─── Payouts (statement reconciliation) ────────────────────────────────────
+  //
+  // GET {MONTONIO_URL}/stores/:storeUuid/payouts            → list payouts
+  // GET .../payouts/:payoutUuid/export-json                 → { url } to the
+  //                                                           order list file
+  //
+  // Auth: a JWT signed with the secret key, sent as `Authorization: Bearer`.
+  // Requires MONTONIO_STORE_UUID. All calls fail soft (return null) so the
+  // statement UI falls back to manual entry.
+
+  isPayoutsConfigured: (): boolean =>
+    Boolean(process.env.MONTONIO_STORE_UUID && montonioUrl),
+
+  createAuthToken: (): string =>
+    jwt.sign({ accessKey: getPublicKey() }, getPrivateKey(), {
+      algorithm: "HS256",
+      expiresIn: "10m",
+    }),
+
+  /**
+   * Recent payouts, newest first. `[]` on any failure.
+   */
+  listPayouts: async (limit = 50): Promise<MontonioPayout[]> => {
+    if (!montonio.isPayoutsConfigured()) return [];
+    const storeUuid = process.env.MONTONIO_STORE_UUID;
+    try {
+      const res = await fetch(
+        `${montonioUrl}/stores/${storeUuid}/payouts?limit=${limit}&offset=0&order=DESC`,
+        { headers: { Authorization: `Bearer ${montonio.createAuthToken()}` } },
+      );
+      if (!res.ok) return [];
+      const body = (await res.json()) as
+        | MontonioPayout[]
+        | { data?: MontonioPayout[] };
+      return Array.isArray(body) ? body : (body.data ?? []);
+    } catch {
+      return [];
+    }
+  },
+
+  /**
+   * The order list for one payout → merchant references. `null` on any failure
+   * (caller should fall back to manual reconciliation).
+   */
+  getPayoutOrders: async (
+    payoutUuid: string,
+  ): Promise<MontonioPayoutOrder[] | null> => {
+    if (!montonio.isPayoutsConfigured()) return null;
+    const storeUuid = process.env.MONTONIO_STORE_UUID;
+    try {
+      const res = await fetch(
+        `${montonioUrl}/stores/${storeUuid}/payouts/${payoutUuid}/export-json`,
+        { headers: { Authorization: `Bearer ${montonio.createAuthToken()}` } },
+      );
+      if (!res.ok) return null;
+      const first = (await res.json()) as
+        | { url?: string }
+        | MontonioPayoutOrder[];
+      // Response is either the rows directly or a URL to a JSON file of rows.
+      if (Array.isArray(first)) return first;
+      if (!first.url) return null;
+      const fileRes = await fetch(first.url);
+      if (!fileRes.ok) return null;
+      const rows = (await fileRes.json()) as
+        | MontonioPayoutOrder[]
+        | { orders?: MontonioPayoutOrder[] };
+      return Array.isArray(rows) ? rows : (rows.orders ?? null);
+    } catch {
+      return null;
+    }
+  },
 };
+
+export interface MontonioPayout {
+  uuid: string;
+  status?: string;
+  currency?: string;
+  /** major units, e.g. "673.10" */
+  amount?: string | number;
+  createdAt?: string;
+  [key: string]: unknown;
+}
+
+export interface MontonioPayoutOrder {
+  merchantReference?: string;
+  merchant_reference?: string;
+  grandTotal?: string | number;
+  [key: string]: unknown;
+}
 
 export default montonio;

--- a/backend/src/utils/reconciliation.ts
+++ b/backend/src/utils/reconciliation.ts
@@ -43,6 +43,8 @@ export interface ReconcilableDonation {
   datetime: string;
   companyCode: string | null;
   donorIdCode: string | null;
+  /** display only — the matcher ignores these */
+  donorName?: string | null;
 }
 
 export interface ReconciliationReport {

--- a/backend/src/utils/reconciliation.ts
+++ b/backend/src/utils/reconciliation.ts
@@ -10,7 +10,12 @@
  */
 import { parse } from "csv-parse/sync";
 
-export type MatchSource = "selgitus-id" | "idcode-amount-date" | "manual";
+export type MatchSource =
+  | "selgitus-id"
+  | "idcode-amount-date"
+  | "manual"
+  | "recurring-import"
+  | "card-payout";
 
 export interface BankTransaction {
   /** Kuupäev, ISO `YYYY-MM-DD` */

--- a/backend/src/utils/statement.ts
+++ b/backend/src/utils/statement.ts
@@ -135,6 +135,11 @@ export function planRecurringImport(
   txn: BankTransaction,
   template: RecurringTemplate,
 ): RecurringImport {
+  if (template.orgSplit.length === 0) {
+    throw new Error(
+      `Recurring template #${template.id} has no organization split`,
+    );
+  }
   const amountCents = txn.amountCents;
   const multiplier = amountCents / template.amount;
 
@@ -186,10 +191,39 @@ export function categorizeStatement(input: StatementInput): StatementReport {
     },
   };
 
-  // Step 2: assign codes to existing unreconciled donations.
+  // Step 2: assign codes to existing unreconciled donations — but never a code
+  // that is already on a donation or on the ignore list (matchDonations only
+  // sees `unreconciledDonations`, so it can still land on an in-window
+  // same-amount donation for a code the operator retired last time).
   const match = matchDonations(credits, input.unreconciledDonations);
-  report.reconcile = match.matched;
-  const claimedByReconcile = new Set(match.matched.map((m) => m.archivingCode));
+  const eligible = match.matched.filter(
+    (m) =>
+      !input.reconciledCodes.has(m.archivingCode) &&
+      !input.ignoredCodes.has(m.archivingCode),
+  );
+
+  // A single bank line matched to >1 existing donation by amount+date is
+  // almost always the wrong month, not a real batch — route those codes to
+  // "needs a decision" instead of auto-checking every donation. `selgitus-id`
+  // is exempt (it names a specific donation id).
+  const byCode = new Map<string, typeof eligible>();
+  for (const m of eligible) {
+    const arr = byCode.get(m.archivingCode) ?? [];
+    arr.push(m);
+    byCode.set(m.archivingCode, arr);
+  }
+  const ambiguousCodes = new Set<string>();
+  report.reconcile = [];
+  for (const [code, ms] of byCode) {
+    if (ms.length === 1 || ms.every((m) => m.source === "selgitus-id")) {
+      report.reconcile.push(...ms);
+    } else {
+      ambiguousCodes.add(code);
+    }
+  }
+  const claimedByReconcile = new Set(
+    report.reconcile.map((m) => m.archivingCode),
+  );
 
   for (const txn of credits) {
     const code = txn.archivingCode;
@@ -204,6 +238,13 @@ export function categorizeStatement(input: StatementInput): StatementReport {
     }
     if (claimedByReconcile.has(code)) {
       continue; // handled in report.reconcile
+    }
+    if (ambiguousCodes.has(code)) {
+      report.needsDecision.push({
+        transaction: txn,
+        reason: `matches ${byCode.get(code)?.length ?? 2} existing donations — assign one manually`,
+      });
+      continue;
     }
 
     // Step 4: card / processor payout — donations resolved later via Montonio.
@@ -229,6 +270,13 @@ export function categorizeStatement(input: StatementInput): StatementReport {
         report.needsDecision.push({
           transaction: txn,
           reason: "no recurring template predates this payment",
+        });
+        continue;
+      }
+      if (template.orgSplit.length === 0) {
+        report.needsDecision.push({
+          transaction: txn,
+          reason: "recurring template has no organization split",
         });
         continue;
       }

--- a/backend/src/utils/statement.ts
+++ b/backend/src/utils/statement.ts
@@ -1,0 +1,251 @@
+/**
+ * Bank-statement categoriser — turns a parsed LHV statement + current DB state
+ * into a review plan for the admin "statement import" tool.
+ *
+ * Pure: no DB, no `strapi`, no network. The caller supplies current DB state
+ * (unreconciled donations, already-used archiving codes, the ignore list, and a
+ * donor→templates lookup) and, later, resolved card payouts.
+ *
+ * Builds on `reconciliation.ts` (`matchDonations`) for the "assign a code to an
+ * existing donation" case.
+ */
+import {
+  matchDonations,
+  type BankTransaction,
+  type ReconcilableDonation,
+  type MatchSource,
+} from "./reconciliation";
+import { resizeOrganizationDonations } from "./donation";
+
+// ─── Injected DB shapes ──────────────────────────────────────────────────────
+
+export interface RecurringTemplate {
+  id: number;
+  donorId: number;
+  /** ISO datetime the template was created */
+  datetime: string;
+  /** template amount, cents */
+  amount: number;
+  companyName: string | null;
+  companyCode: string | null;
+  bank: string | null;
+  /** organization split, cents, sums to `amount` */
+  orgSplit: { organizationInternalId: string; amount: number }[];
+}
+
+export interface DonorTemplates {
+  donorId: number;
+  /** newest first */
+  templates: RecurringTemplate[];
+}
+
+export interface StatementInput {
+  transactions: BankTransaction[];
+  /** finalized donations that do NOT yet have a transaction_id */
+  unreconciledDonations: ReconcilableDonation[];
+  /** archiving codes already recorded on some donation */
+  reconciledCodes: Set<string>;
+  /** archiving codes in `ignored_bank_transactions` */
+  ignoredCodes: Set<string>;
+  /** idCode OR company code → that donor and their templates (newest first) */
+  donorsByCode: Map<string, DonorTemplates>;
+}
+
+// ─── Report ──────────────────────────────────────────────────────────────────
+
+export interface PlannedOrgDonation {
+  organizationInternalId: string;
+  amountCents: number;
+}
+
+export interface RecurringImport {
+  archivingCode: string;
+  transaction: BankTransaction;
+  donorId: number;
+  templateId: number;
+  templateAmountCents: number;
+  amountCents: number;
+  /** ISO datetime for the new donation (transaction date, noon local) */
+  datetime: string;
+  companyName: string | null;
+  companyCode: string | null;
+  paymentMethod: string | null;
+  iban: string;
+  orgDonations: PlannedOrgDonation[];
+  /** true when the paid amount differs from the template amount */
+  amountDrifted: boolean;
+}
+
+export interface StatementReport {
+  /** step 2 — assign a code to exactly one existing unreconciled donation */
+  reconcile: {
+    donationId: number;
+    archivingCode: string;
+    source: MatchSource;
+  }[];
+  /** step 3 — create a finalized donation from a recurring template */
+  recurringImports: RecurringImport[];
+  /** step 4 — Montonio/processor payout; donations resolved later via the API */
+  cardPayouts: BankTransaction[];
+  /** step 5 — donation-like but unresolved; operator handles outside this tool */
+  needsDecision: { transaction: BankTransaction; reason: string }[];
+  /** step 6 — offer to ignore */
+  notADonation: BankTransaction[];
+  counts: {
+    creditTransactions: number;
+    alreadyReconciled: number;
+    ignored: number;
+  };
+}
+
+// ─── Classification helpers ──────────────────────────────────────────────────
+
+const DONATION_SELGITUS =
+  /anneta\s*targalt|annetus|p[üu]siannetus|efektiivne\s*altruism/i;
+
+/** Montonio (incl. its Stripe-labelled card settlements) aggregated payout. */
+export function looksLikeCardPayout(txn: BankTransaction): boolean {
+  const name = txn.counterpartyName.toLowerCase();
+  const selg = txn.description.toLowerCase();
+  if (name.includes("montonio")) return true;
+  if (name === "stripe" && selg.includes("montonio")) return true;
+  if (selg.includes("card payout") || selg.includes("payout ")) return true;
+  return false;
+}
+
+/** Montonio payout UUID embedded in the Selgitus, if present (often truncated). */
+export function parsePayoutUuidPrefix(description: string): string | null {
+  const m = /payout\s+([0-9a-f-]{8,})/i.exec(description);
+  return m ? m[1].toLowerCase() : null;
+}
+
+// ─── Recurring import planning (mirror of donation.insertFromTransaction) ─────
+
+/** First template created on/before the transaction date (+24h grace). */
+export function selectTemplate(
+  templates: RecurringTemplate[],
+  transactionDate: string,
+): RecurringTemplate | null {
+  const limit =
+    Date.parse(`${transactionDate.slice(0, 10)}T00:00:00Z`) + 86_400_000;
+  return templates.find((t) => Date.parse(t.datetime) <= limit) ?? null;
+}
+
+export function planRecurringImport(
+  txn: BankTransaction,
+  template: RecurringTemplate,
+): RecurringImport {
+  const amountCents = txn.amountCents;
+  const multiplier = amountCents / template.amount;
+
+  const resized = resizeOrganizationDonations(
+    template.orgSplit,
+    multiplier,
+    amountCents,
+  );
+
+  const datetime = new Date(`${txn.date.slice(0, 10)}T12:00:00`);
+
+  return {
+    archivingCode: txn.archivingCode,
+    transaction: txn,
+    donorId: template.donorId,
+    templateId: template.id,
+    templateAmountCents: template.amount,
+    amountCents,
+    datetime: datetime.toISOString(),
+    companyName: template.companyName,
+    companyCode: template.companyCode,
+    paymentMethod: template.bank,
+    iban: txn.counterpartyAccount,
+    orgDonations: resized.map((o) => ({
+      organizationInternalId: o.organizationInternalId,
+      amountCents: o.amount,
+    })),
+    amountDrifted: amountCents !== template.amount,
+  };
+}
+
+// ─── Categoriser ─────────────────────────────────────────────────────────────
+
+export function categorizeStatement(input: StatementInput): StatementReport {
+  const credits = input.transactions.filter(
+    (t) => t.direction === "C" && t.archivingCode !== "",
+  );
+
+  const report: StatementReport = {
+    reconcile: [],
+    recurringImports: [],
+    cardPayouts: [],
+    needsDecision: [],
+    notADonation: [],
+    counts: {
+      creditTransactions: credits.length,
+      alreadyReconciled: 0,
+      ignored: 0,
+    },
+  };
+
+  // Step 2: assign codes to existing unreconciled donations.
+  const match = matchDonations(credits, input.unreconciledDonations);
+  report.reconcile = match.matched;
+  const claimedByReconcile = new Set(match.matched.map((m) => m.archivingCode));
+
+  for (const txn of credits) {
+    const code = txn.archivingCode;
+
+    if (input.ignoredCodes.has(code)) {
+      report.counts.ignored++;
+      continue;
+    }
+    if (input.reconciledCodes.has(code)) {
+      report.counts.alreadyReconciled++;
+      continue;
+    }
+    if (claimedByReconcile.has(code)) {
+      continue; // handled in report.reconcile
+    }
+
+    // Step 4: card / processor payout — donations resolved later via Montonio.
+    if (looksLikeCardPayout(txn)) {
+      report.cardPayouts.push(txn);
+      continue;
+    }
+
+    // Step 3: recurring import.
+    const donor = txn.idOrRegCode
+      ? input.donorsByCode.get(txn.idOrRegCode)
+      : undefined;
+    if (donor) {
+      if (donor.templates.length === 0) {
+        report.needsDecision.push({
+          transaction: txn,
+          reason: "known donor, no recurring template",
+        });
+        continue;
+      }
+      const template = selectTemplate(donor.templates, txn.date);
+      if (!template) {
+        report.needsDecision.push({
+          transaction: txn,
+          reason: "no recurring template predates this payment",
+        });
+        continue;
+      }
+      report.recurringImports.push(planRecurringImport(txn, template));
+      continue;
+    }
+
+    // Step 5 / 6.
+    if (DONATION_SELGITUS.test(txn.description)) {
+      report.needsDecision.push({
+        transaction: txn,
+        reason: "donation-like description, unrecognised sender",
+      });
+    } else {
+      report.notADonation.push(txn);
+    }
+  }
+
+  return report;
+}

--- a/backend/src/utils/statement.ts
+++ b/backend/src/utils/statement.ts
@@ -103,20 +103,6 @@ export interface StatementReport {
 const DONATION_SELGITUS =
   /anneta\s*targalt|annetus|p[üu]siannetus|efektiivne\s*altruism/i;
 
-/**
- * Estonian Tax Board income-tax rebate on donations ("Fidek … tulumaks …
- * annetus, isikukood …"). Real money, but it already counted as the donor's
- * gift — no donation record is created for it.
- */
-function isTaxRebate(txn: BankTransaction): boolean {
-  const name = txn.counterpartyName.toLowerCase();
-  return (
-    txn.idOrRegCode === "70000272" ||
-    name.includes("rahandusministeerium") ||
-    txn.description.toLowerCase().includes("maksu ja tolliamet")
-  );
-}
-
 /** Montonio (incl. its Stripe-labelled card settlements) aggregated payout. */
 export function looksLikeCardPayout(txn: BankTransaction): boolean {
   const name = txn.counterpartyName.toLowerCase();
@@ -218,12 +204,6 @@ export function categorizeStatement(input: StatementInput): StatementReport {
     }
     if (claimedByReconcile.has(code)) {
       continue; // handled in report.reconcile
-    }
-
-    // Tax-board rebate — never a donation record.
-    if (isTaxRebate(txn)) {
-      report.notADonation.push(txn);
-      continue;
     }
 
     // Step 4: card / processor payout — donations resolved later via Montonio.

--- a/backend/src/utils/statement.ts
+++ b/backend/src/utils/statement.ts
@@ -103,6 +103,20 @@ export interface StatementReport {
 const DONATION_SELGITUS =
   /anneta\s*targalt|annetus|p[üu]siannetus|efektiivne\s*altruism/i;
 
+/**
+ * Estonian Tax Board income-tax rebate on donations ("Fidek … tulumaks …
+ * annetus, isikukood …"). Real money, but it already counted as the donor's
+ * gift — no donation record is created for it.
+ */
+function isTaxRebate(txn: BankTransaction): boolean {
+  const name = txn.counterpartyName.toLowerCase();
+  return (
+    txn.idOrRegCode === "70000272" ||
+    name.includes("rahandusministeerium") ||
+    txn.description.toLowerCase().includes("maksu ja tolliamet")
+  );
+}
+
 /** Montonio (incl. its Stripe-labelled card settlements) aggregated payout. */
 export function looksLikeCardPayout(txn: BankTransaction): boolean {
   const name = txn.counterpartyName.toLowerCase();
@@ -204,6 +218,12 @@ export function categorizeStatement(input: StatementInput): StatementReport {
     }
     if (claimedByReconcile.has(code)) {
       continue; // handled in report.reconcile
+    }
+
+    // Tax-board rebate — never a donation record.
+    if (isTaxRebate(txn)) {
+      report.notADonation.push(txn);
+      continue;
     }
 
     // Step 4: card / processor payout — donations resolved later via Montonio.

--- a/docs/TRANSACTION_ID_RECONCILIATION_PLAN.md
+++ b/docs/TRANSACTION_ID_RECONCILIATION_PLAN.md
@@ -288,129 +288,138 @@ since they spread the row.
 
 ---
 
-# Phase 2 — CSV import in the admin panel
+# Phase 2 — Statement import in the admin panel
 
-Replace `import_lhv_donations.py`. One CSV upload does two jobs:
+Replaces `import_lhv_donations.py` **and** `match_donations_to_lhv_transactions.py`.
+The primary job is **keeping the donation ledger current** — most of a monthly
+statement is recurring bank payments with no donation record yet (as of the
+backfill: ~150 payments / 4 months of backlog, dashboard stats stale). Assigning
+transaction IDs rides along.
 
-1. assign archiving codes to existing donations (reconciliation)
-2. create finalized donations for **recurring bank transfers** not yet in the DB
+## 2.0 What the categoriser does
 
-## 2.1 Endpoints — `admin-panel` plugin (first write paths)
+Parse the uploaded LHV CSV. For every credit line with an archiving code, in
+order:
 
-`backend/src/plugins/admin-panel/server/routes/reconciliation.ts`
-(`content-api`, `DonationAdmin`-gated, audit-logged):
+1. **already done** — some donation already has this `transaction_id`, or the
+   code is in the ignore list → count only, no action.
+2. **reconcile to existing donation** — the `matchDonations` engine (Phase 1.2)
+   finds exactly one still-unreconciled donation (`selgitus-id` or
+   `idcode-amount-date`) → propose assigning the code.
+3. **recurring import** — sender `idOrRegCode` matches a donor
+   (`donor.idCode`, or a recurring template's `companyCode`) who has a template
+   dated on/before the transaction → propose **creating** a finalized donation
+   from that template (amount from the payment, org split scaled — see 2.1).
+4. **card payout** — counterparty is Montonio / "Card payout …" / "STRIPE …
+   MONTONIO FINANCE" → resolve via the Montonio payouts API (2.2); assign the
+   code to every donation in the payout. Manual checklist fallback.
+5. **needs a decision** — donation-like `Selgitus` but no donor/template match
+   (new donor, unusual company) → **list only, no action** (handled
+   exceptionally, outside this tool).
+6. **not a donation** — everything else (interest, refunds, internal transfers)
+   → offer to add to the ignore list.
 
-### `POST /admin-panel/reconciliation/preview`
+## 2.1 Recurring import — mirror of `insertFromTransaction`
 
-Multipart CSV upload. Returns:
+Per [insertFromTransaction](../backend/src/plugins/donations/server/services/donation.ts):
 
-```jsonc
-{
-  "matched": [
-    { "donationId": 1337, "archivingCode": "...", "source": "selgitus-id" },
-  ],
-  "ambiguous": [
-    {
-      "donationId": 42,
-      "candidates": [
-        /* transaction rows */
-      ],
-    },
-  ],
-  "newRecurringDonations": [
-    {
-      "transaction": {
-        /* row */
-      },
-      "donorId": 12,
-      "recurringDonationId": 5,
-      "amountCents": 3000,
-      "date": "2026-01-15",
-    },
-  ],
-  "donationlessTransactions": [
-    /* rows, minus the newRecurring ones */
-  ],
-  "transactionlessDonations": [
-    { "id": 99, "date": "...", "amountCents": 3000, "donor": "..." },
-  ],
-}
-```
+- donor via `donor.findDonor(idOrRegCode)` (idCode, then recurring
+  `companyCode`)
+- templates via `recurringDonationsRepository.findByDonorId` (newest first);
+  pick the **first with `datetime <= transactionDate + 24h`**
+- new donation: `amount` = payment, `finalized: true`,
+  `companyName/companyCode` + `paymentMethod` (= `bank`) from the template,
+  `iban` = counterparty account, `transactionId` = archiving code,
+  `transactionMatchSource = 'recurring-import'`
+- org split: template's `organizationRecurringDonations` scaled by
+  `payment / template.amount` via `resizeOrganizationDonations` (rounding
+  fixup). **No operator adjustment** — amount drift (~25% of donors) is handled
+  by the proportional scale, same as the Python script does today.
+- ambiguity (donor has 2+ candidate templates, no template predates) → surfaces
+  in "needs a decision", not auto-created.
 
-`newRecurringDonations` detection reuses the logic from
-`donation.service` `insertFromTransaction` / `findTransactionDonation`:
-credit transaction whose `idOrRegCode` matches a donor with an active recurring
-template, no existing donation for that date/amount, template datetime on or
-before the transaction date.
+New `transaction_match_source` value: `'recurring-import'` (alongside
+`selgitus-id | idcode-amount-date | manual`).
 
-### `POST /admin-panel/reconciliation/apply`
+## 2.2 Montonio payouts client — `backend/src/utils/montonio.ts`
 
-```jsonc
-{
-  "assignments": [{ "donationId": 1337, "archivingCode": "..." }],
-  "createDonations": [
-    {
-      "transactionArchivingCode": "...",
-      "recurringDonationId": 5,
-      "idCode": "...",
-      "amountCents": 3000,
-      "date": "...",
-      "iban": "...",
-    },
-  ],
-}
-```
+- `GET {MONTONIO_URL}/stores/:storeUuid/payouts?limit&offset&order` — list
+- `GET …/payouts/:payoutUuid/export-json` — returns a download URL; fetch it for
+  the order list (each `merchantReference` = `<prefix> <donationId>`)
+- auth: JWT signed with `MONTONIO_PRIVATE`, `Authorization: Bearer <jwt>` (GET)
+- needs `MONTONIO_STORE_UUID` in config (new)
 
-- assignments → `donationsRepository.setTransactionId(..., 'manual')`
-  (operator-confirmed ⇒ `manual`; keep the engine's source only for
-  untouched auto-matches)
-- createDonations → extend
-  `donation.service.insertFromTransaction` to accept and store
-  `transactionId`, then call it per row
+**Spike first** — confirm the existing creds authorise these endpoints and the
+export contains merchant references. If not, section 4 stays a manual checklist
+(sum candidate card donations vs `payout / (1 - feeRate)`).
 
-Config: raise `multipart`/`formLimit` for these two routes (default 1 MB; the
-full statement is ~300 KB today but grows).
+The payout UUID is in the CSV `Selgitus` (`Card payout faab4de5-…`), often
+truncated — match by UUID prefix, else by amount+date against the payouts list.
 
-`id_code_replacement_map` (from `import_lhv_donations.py`) becomes a config
-value, not a hardcode.
+## 2.3 Ignore list
 
-## 2.2 Admin UI — `admin/app/(dashboard)/reconciliation/`
+New table `ignored_bank_transactions` (`archiving_code` PK, `reason`,
+`created_at`, `created_by`). Checked in step 1; populated from step 6. One-time
+bulk seed for the current backlog of non-donation credits.
 
-- **Upload** page → POSTs to `preview`.
-- **Review** screen:
-  - _Proposed matches_ — table, accept / reject / edit archiving code per row
-  - _Ambiguous_ — pick the correct transaction from candidates
-  - _New recurring donations_ — checkbox list; shows donor, amount, date,
-    target template
-  - _Unmatched_ (both directions) — informational, exportable to CSV
-  - **Apply** → POSTs to `apply`, shows a result summary
-- Nav entry in `admin/app/(dashboard)/layout.tsx`.
+## 2.4 Endpoints — `admin-panel` plugin (first write paths)
 
-## 2.3 Retire the Python scripts
+`content-api`, `DonationAdmin`-gated, `auditLog`ged.
 
-Once 2.2 is in use, delete from the private `Donations/` repo:
-`match_donations_to_lhv_transactions.py`, `import_lhv_donations.py`,
-`import_single_transaction.py`. Monthly flow becomes: export CSV from LHV →
-upload → review → apply.
+- `POST /admin-panel/statement/preview` — multipart CSV → the categorised
+  report (all six buckets; buckets 1 + auto-2 collapsed to counts). No writes.
+- `POST /admin-panel/statement/apply` — body: confirmed assignments, confirmed
+  recurring-imports, confirmed ignores. Runs in one transaction, returns a
+  summary. One click (per the locked decision).
+
+Raise the route's `multipart` limit (statement ~0.5 MB, grows).
+`id_code_replacement_map` → config value.
+
+## 2.5 Admin UI — `admin/app/(dashboard)/statement/`
+
+Upload (browser file-picker) → review page:
+
+- **Recurring payments to import** — donor · paid · template · scaled org split ·
+  `[import]`; "import all clean" bulk action
+- **Card payouts** — per payout: amount, fee, resolved donations (or manual
+  checklist with running total)
+- **Needs a decision** — read-only list
+- **Not a donation** — checkboxes → ignore
+- **Auto-reconciled / already done** — counts
+- **Apply** → `apply`, then a result summary
+
+Nav entry in `admin/app/(dashboard)/layout.tsx`.
+
+## 2.6 First run + retire the scripts
+
+First real use clears the ~4-month backlog. Then delete from the private
+`Donations/` repo: `match_donations_to_lhv_transactions.py`,
+`import_lhv_donations.py`, `import_single_transaction.py`. `reconcile.ts` /
+`yarn reconcile` stays for one-off DB-side fixes.
+
+## Build order
+
+1. Montonio payouts spike (verify creds + response shape)
+2. Categoriser + recurring-import computation — pure, unit-tested
+3. `ignored_bank_transactions` table + migration `0004`
+4. `statement` service (preview) wiring DB + engine
+5. `preview` / `apply` endpoints + routes
+6. Admin UI
+7. Card-payout resolution (Montonio client → categoriser)
 
 ---
 
 # Decisions locked in
 
-- `transaction_id` is nullable permanently (Montonio payouts lag; corrections).
-- `transaction_id` is **not** unique (batch payouts).
+- `transaction_id` nullable permanently, not unique.
 - Canonical CSV input = LHV Estonian headers; English export also accepted.
-- New dependency: `csv-parse` (backend).
-- Backfill writes directly to Postgres via the Drizzle client on the VPS; the
-  admin endpoints are for the ongoing monthly flow.
-- Operator-confirmed matches in the UI are stored as `source = 'manual'`.
-
-# Open questions
-
-- One-time prod check (see 1.1): does `admin_audit_log` exist and is `0002` in
-  `drizzle.__drizzle_migrations`? Determines nothing about the code — the
-  `IF NOT EXISTS` guard covers both — but good to confirm before deploying.
-- `overrides.csv`: caller's choice; the script only needs a path. Default to
-  keeping it in the private `Donations/` repo alongside the bank exports.
-- Phase 2 `apply`: create the missing recurring donations and reconcile in one
-  request, or two explicit operator steps? (Leaning: one request, one summary.)
+- Deps: `csv-parse` (backend).
+- Phase 1 backfill wrote directly to Postgres via `yarn reconcile`; Phase 2
+  endpoints are the ongoing flow.
+- Operator-confirmed matches → `source = 'manual'`; auto recurring creations →
+  `'recurring-import'`.
+- Recurring import: proportional org-split scaling, **no** per-line adjustment UI.
+- Unknown senders / no template: **listed, never auto-created** by this tool.
+- Card payouts: resolve via Montonio payouts API; manual checklist fallback.
+- Apply is one request / one click.
+- Ignore list persists in its own table.

--- a/docs/TRANSACTION_ID_RECONCILIATION_PLAN.md
+++ b/docs/TRANSACTION_ID_RECONCILIATION_PLAN.md
@@ -296,6 +296,23 @@ statement is recurring bank payments with no donation record yet (as of the
 backfill: ~150 payments / 4 months of backlog, dashboard stats stale). Assigning
 transaction IDs rides along.
 
+**Status: built, not yet deployed.** Commits `f6d5c1e`, `7554d14`, `bcdff3d`,
+`7b8d8de`. Routing verified (403/404); service smoke-tested end-to-end against a
+scratch DB (preview + apply + idempotent re-run); 98 unit tests. Not yet
+exercised over HTTP with a real token, and the Montonio payouts API is coded but
+unverified against the live merchant account.
+
+**Before deploy:**
+
+- migration `0004` applies (`ignored_bank_transactions`) — same
+  `drizzle-kit migrate` step; `CREATE TABLE IF NOT EXISTS`
+- `MONTONIO_STORE_UUID` in the VPS `.env` (card-payout auto-resolve is off
+  without it — manual entry still works)
+- re-check `drizzle.__drizzle_migrations` count goes 4 → 5
+- verify the Montonio payouts endpoints accept the existing key pair; if not,
+  card payouts stay manual and that's fine for v1
+- first real run clears the recurring backlog and updates the dashboard
+
 ## 2.0 What the categoriser does
 
 Parse the uploaded LHV CSV. For every credit line with an archiving code, in


### PR DESCRIPTION
Phase 2 of docs/TRANSACTION_ID_RECONCILIATION_PLAN.md — a statement-import tool that replaces import_lhv_donations.py + match_donations_to_lhv_transactions.py.

What it does: Upload a monthly LHV CSV at /statement. Every credit line is bucketed → already-done / recurring-payment (create from template) / bank-transfer (assign ID) / card-payout / not-a-donation / needs-a-decision. One Apply creates the donations, assigns transaction IDs, records ignores + sender→donor aliases, in one transaction. DonationAdmin-gated (admin panel's first write path), audit-logged.

Schema: 0004 ignored_bank_transactions, 0005 sender_donor_aliases (both IF NOT EXISTS). __drizzle_migrations 4 → 6 via the existing deploy step.

Validated: 82 unit tests, builds clean. End-to-end against a prod-DB copy — a catch-up creates all donations with correct donors/amounts/scaled splits (verified sums), saves the alias, ignores the refund. Not yet exercised over HTTP on prod; Montonio payouts API coded from docs, unverified against the live merchant (fails soft to manual).

Deploy: deploy-local.sh + git push vercel main + optional MONTONIO_STORE_UUID. Import month-by-month.

Deferred to Phase 3: the transactions table + reconciliation/money-flow view.